### PR TITLE
fix: 🐛 formal analyzer context intefaces and processing touch-ups

### DIFF
--- a/analyzer_interface/__init__.py
+++ b/analyzer_interface/__init__.py
@@ -1,8 +1,8 @@
 from .column_automap import UserInputColumn, column_automap
 from .data_type_compatibility import get_data_type_compatibility_score
-from .interface import (AnalyzerDeclaration, AnalyzerInput, AnalyzerInterface,
-                        AnalyzerOutput, DataType, InputColumn, OutputColumn,
-                        SecondaryAnalyzerDeclaration,
-                        SecondaryAnalyzerInterface, WebPresenterDeclaration,
-                        WebPresenterInterface)
+from .declaration import (AnalyzerDeclaration, SecondaryAnalyzerDeclaration,
+                          WebPresenterDeclaration)
+from .interface import (AnalyzerInput, AnalyzerInterface, AnalyzerOutput,
+                        DataType, InputColumn, OutputColumn,
+                        SecondaryAnalyzerInterface, WebPresenterInterface)
 from .suite import AnalyzerSuite

--- a/analyzer_interface/context.py
+++ b/analyzer_interface/context.py
@@ -1,0 +1,135 @@
+from abc import ABC, abstractmethod
+
+import polars as pl
+from dash import Dash
+from pydantic import BaseModel
+from .interface import SecondaryAnalyzerInterface
+from typing import TypeVar
+
+
+class PrimaryAnalyzerContext(ABC, BaseModel):
+  temp_dir: str
+  """
+  Gets the temporary directory that the module can freely write content to
+  during its lifetime. This directory will not persist between runs.
+  """
+
+  @abstractmethod
+  def input(self) -> "InputTableReader":
+    """
+    Gets the input reader context.
+
+    **Note that this is in function form** even though one input is expected,
+    in anticipation that we may want to support multiple inputs in the future.
+    """
+    pass
+
+  @abstractmethod
+  def output(self, output_id: str) -> "TableWriter":
+    """
+    Gets the output writer context for the specified output ID.
+    """
+    pass
+
+
+class BaseDerivedModuleContext(ABC, BaseModel):
+  """
+  Common interface for secondary analyzers and web presenters runtime contexts.
+  """
+
+  temp_dir: str
+  """
+  Gets the temporary directory that the module can freely write content to
+  during its lifetime. This directory will not persist between runs.
+  """
+
+  @property
+  @abstractmethod
+  def base(self) -> "AssetsReader":
+    """
+    Gets the base primary analyzer's context, which lets you inspect and load its
+    outputs.
+    """
+    pass
+
+  @abstractmethod
+  def dependency(self, secondary_interface: SecondaryAnalyzerInterface) -> "AssetsReader":
+    """
+    Gets the context of a secondary analyzer the current module depends on, which
+    lets you inspect and load its outputs.
+    """
+    pass
+
+
+class WebPresenterContext(BaseDerivedModuleContext):
+  dash_app: Dash
+  """
+  The Dash app that is being built.
+  """
+
+  @property
+  @abstractmethod
+  def state_dir(self) -> str:
+    """
+    Gets the directory where the web presenter can store state that persists
+    between runs. This state space is unique for each
+    project/primary analyzer/web presenter combination.
+    """
+    pass
+
+  class Config:
+    arbitrary_types_allowed = True
+
+
+class SecondaryAnalyzerContext(BaseDerivedModuleContext):
+  @abstractmethod
+  def output(self, output_id: str) -> "TableWriter":
+    """
+    Gets the output writer context
+    """
+    pass
+
+
+class AssetsReader(ABC):
+  @abstractmethod
+  def table(self, output_id: str) -> "TableReader":
+    """
+    Gets the table reader for the specified output.
+    """
+    pass
+
+
+class TableReader(ABC):
+  @property
+  @abstractmethod
+  def parquet_path(self) -> str:
+    """
+    Gets the path to the table's parquet file. The module should expect a parquet
+    file here.
+    """
+    pass
+
+
+PolarsDataFrameLike = TypeVar("PolarsDataFrameLike", bound=pl.DataFrame)
+
+
+class InputTableReader(TableReader):
+  @abstractmethod
+  def preprocess[PolarsDataFrameLike](self, df: PolarsDataFrameLike) -> PolarsDataFrameLike:
+    """
+    Given the manually loaded user input dataframe, apply column mapping and
+    semantic transformations to give the input dataframe that the analyzer
+    expects.
+    """
+    pass
+
+
+class TableWriter(ABC):
+  @property
+  @abstractmethod
+  def parquet_path(self) -> str:
+    """
+    Gets the path to the table's parquet file. The module should write a parquet
+    file to it.
+    """
+    pass

--- a/analyzer_interface/declaration.py
+++ b/analyzer_interface/declaration.py
@@ -1,0 +1,62 @@
+from typing import Callable
+
+from .context import (PrimaryAnalyzerContext, SecondaryAnalyzerContext,
+                      WebPresenterContext)
+from .interface import (AnalyzerInterface, SecondaryAnalyzerInterface,
+                        WebPresenterInterface)
+
+
+class AnalyzerDeclaration(AnalyzerInterface):
+  """
+  The analyzer's entry point. The function should ensure that the outputs
+  specified in the interface are generated.
+  """
+  entry_point: Callable[[PrimaryAnalyzerContext], None]
+
+  def __init__(self, interface: AnalyzerInterface, main: Callable):
+    super().__init__(**interface.model_dump(), entry_point=main)
+
+
+class SecondaryAnalyzerDeclaration(SecondaryAnalyzerInterface):
+  entry_point: Callable[["SecondaryAnalyzerContext"], None]
+  """
+  The analyzer's entry point. The function should ensure that the outputs
+  specified in the interface are generated.
+  """
+
+  def __init__(self, interface: SecondaryAnalyzerInterface, main: Callable):
+    super().__init__(**interface.model_dump(), entry_point=main)
+
+
+class WebPresenterDeclaration(WebPresenterInterface):
+  factory: Callable[["WebPresenterContext"], None]
+
+  server_name: str
+
+  def __init__(self, interface: WebPresenterInterface, factory: Callable, name: str):
+    """Creates a web presenter declaration
+
+    Args:
+      interface (WebPresenterInterface): The metadata interface for the web presenter.
+
+      factory (Callable):
+        The factory function that creates a Dash app for the web presenter. It should
+        modify the Dash app in the context to add whatever plotting interface
+        the web presenter needs.
+
+      server_name (str):
+        The server name for the Dash app. Typically, you will use the global
+        variable `__name__` here.
+
+        If your web presenter has assets like images, CSS or JavaScript files,
+        you can put them in a folder named `assets` in the same directory
+        as the file where `__name__` is used. The Dash app will serve these
+        files at the `/assets/` URL, using the python module name in `__name__`
+        to determine the absolute path to the assets folder.
+
+        See Dash documentation for more details: https://dash.plotly.com
+        See also Python documentation for the `__name__` variable:
+        https://docs.python.org/3/tutorial/modules.html
+
+    """
+    super().__init__(**interface.model_dump(), factory=factory, server_name=name)

--- a/analyzer_interface/suite.py
+++ b/analyzer_interface/suite.py
@@ -3,10 +3,10 @@ from typing import Union
 
 from pydantic import BaseModel
 
-from analyzer_interface.interface import (AnalyzerDeclaration,
-                                          AnalyzerInterface,
-                                          SecondaryAnalyzerDeclaration,
-                                          WebPresenterDeclaration)
+from analyzer_interface import (AnalyzerDeclaration, AnalyzerInterface,
+                                SecondaryAnalyzerDeclaration,
+                                SecondaryAnalyzerInterface,
+                                WebPresenterDeclaration)
 
 
 class AnalyzerSuite(BaseModel):
@@ -22,42 +22,52 @@ class AnalyzerSuite(BaseModel):
     ]
 
   @cached_property
-  def primary_analyzers_lookup(self):
+  def _primary_analyzers_lookup(self):
     return {
       analyzer.id: analyzer
       for analyzer in self.primary_anlyzers
     }
 
   def get_primary_analyzer(self, analyzer_id):
-    return self.primary_analyzers_lookup.get(analyzer_id)
+    return self._primary_analyzers_lookup.get(analyzer_id)
 
   @cached_property
-  def secondary_analyzers(self):
+  def _secondary_analyzers(self):
     return [
       analyzer for analyzer in self.all_analyzers
       if isinstance(analyzer, SecondaryAnalyzerDeclaration)
     ]
 
   @cached_property
-  def secondary_analyzers_by_primary(self):
-    return {
-      analyzer.id: {
-        secondary.id: secondary
-        for secondary in self.secondary_analyzers
-        if secondary.base_analyzer.id == analyzer.id
-      }
-      for analyzer in self.primary_anlyzers
-    }
+  def _secondary_analyzers_by_base(self):
+    result: dict[str, dict[str, SecondaryAnalyzerDeclaration]] = {}
+    for secondary in self._secondary_analyzers:
+      base_analyzer = secondary.base_analyzer
+      result.setdefault(base_analyzer.id, {}).update({secondary.id: secondary})
+    return result
 
-  def find_secondary_analyzers(self, primary_analyzer: AnalyzerInterface, *, autorun=False):
-    return [
-      analyzer for analyzer in self.secondary_analyzers
-      if analyzer.base_analyzer.id == primary_analyzer.id
-      if not autorun or analyzer.autorun
-    ]
+  def find_toposorted_secondary_analyzers(self, primary_analyzer: AnalyzerInterface) -> list[SecondaryAnalyzerDeclaration]:
+    result: list[SecondaryAnalyzerDeclaration] = []
+    visited_ids: set[str] = set()
 
-  def get_secondary_analyzer(self, analyzer_id, secondary_id):
-    return self.secondary_analyzers_by_primary.get(analyzer_id, {}).get(secondary_id)
+    def visit(secondary_interface: SecondaryAnalyzerInterface):
+      if secondary_interface.id in visited_ids:
+        return
+      visited_ids.add(secondary_interface.id)
+      for dependency in secondary_interface.depends_on:
+        visit(dependency)
+
+      secondary_declaration = self._secondary_analyzers_by_base.get(
+        primary_analyzer.id, {}).get(secondary_interface.id)
+      assert secondary_declaration is not None
+      result.append(secondary_declaration)
+
+    for secondary in self._secondary_analyzers_by_base.get(primary_analyzer.id, {}).values():
+      visit(secondary)
+    return result
+
+  def get_secondary_analyzer_by_id(self, analyzer_id, secondary_id):
+    return self._secondary_analyzers_by_base.get(analyzer_id, {}).get(secondary_id)
 
   @cached_property
   def web_presenters_by_primary(self):

--- a/analyzers/ngram_stats/interface.py
+++ b/analyzers/ngram_stats/interface.py
@@ -16,7 +16,6 @@ interface = SecondaryAnalyzerInterface(
   name="Copy-Pasta Detector",
   short_description="",
   base_analyzer=ngrams_interface,
-  autorun=True,
   outputs=[
     AnalyzerOutput(
       id=OUTPUT_NGRAM_STATS,

--- a/analyzers/ngram_stats/main.py
+++ b/analyzers/ngram_stats/main.py
@@ -1,17 +1,26 @@
 import polars as pl
 
+from analyzer_interface.context import SecondaryAnalyzerContext
+
 from ..ngrams.interface import (COL_AUTHOR_ID, COL_MESSAGE_ID,
                                 COL_MESSAGE_NGRAM_COUNT, COL_NGRAM_ID,
                                 COL_NGRAM_LENGTH, COL_NGRAM_WORDS,
                                 OUTPUT_MESSAGE_AUTHORS, OUTPUT_MESSAGE_NGRAMS,
                                 OUTPUT_NGRAM_DEFS)
-from .interface import COL_NGRAM_DISTINCT_POSTER_COUNT, COL_NGRAM_TOTAL_REPS, OUTPUT_NGRAM_STATS
+from .interface import (COL_NGRAM_DISTINCT_POSTER_COUNT, COL_NGRAM_TOTAL_REPS,
+                        OUTPUT_NGRAM_STATS)
 
 
-def main(ngrams_outputs: dict[str, pl.DataFrame]):
-  df_message_ngrams = ngrams_outputs[OUTPUT_MESSAGE_NGRAMS]
-  df_ngrams = ngrams_outputs[OUTPUT_NGRAM_DEFS]
-  df_message_authors = ngrams_outputs[OUTPUT_MESSAGE_AUTHORS]
+def main(context: SecondaryAnalyzerContext):
+  df_message_ngrams = pl.read_parquet(
+    context.base.table(OUTPUT_MESSAGE_NGRAMS).parquet_path
+  )
+  df_ngrams = pl.read_parquet(
+    context.base.table(OUTPUT_NGRAM_DEFS).parquet_path
+  )
+  df_message_authors = pl.read_parquet(
+    context.base.table(OUTPUT_MESSAGE_AUTHORS).parquet_path
+  )
 
   df_ngram_total_reps = (
     df_message_ngrams
@@ -38,4 +47,6 @@ def main(ngrams_outputs: dict[str, pl.DataFrame]):
       ).sort(by=COL_NGRAM_TOTAL_REPS, descending=True)
   )
 
-  return {OUTPUT_NGRAM_STATS: df_ngram_summary}
+  df_ngram_summary.write_parquet(
+    context.output(OUTPUT_NGRAM_STATS).parquet_path
+  )

--- a/analyzers/ngram_web/factory.py
+++ b/analyzers/ngram_web/factory.py
@@ -1,52 +1,26 @@
-import polars as pl
-
-from ..ngrams.interface import (COL_AUTHOR_ID, COL_MESSAGE_ID,
-                                COL_MESSAGE_NGRAM_COUNT, COL_NGRAM_ID,
-                                COL_NGRAM_LENGTH, COL_NGRAM_WORDS,
-                                OUTPUT_MESSAGE_AUTHORS, OUTPUT_MESSAGE_NGRAMS,
-                                OUTPUT_NGRAM_DEFS)
-from dash import Dash
-
-from dash.html import Div, H2, P
-from dash.dcc import Graph
-from dash.dependencies import Input, Output
 import plotly.express as px
+import polars as pl
+from dash.dcc import Graph
+from dash.html import H2, Div, P
+
+from analyzer_interface.context import WebPresenterContext
+
+from ..ngram_stats.interface import (COL_NGRAM_DISTINCT_POSTER_COUNT,
+                                     COL_NGRAM_TOTAL_REPS, COL_NGRAM_WORDS,
+                                     OUTPUT_NGRAM_STATS)
+from ..ngram_stats.interface import interface as ngram_stats
 
 
-def factory(ngrams_outputs: dict[str, pl.DataFrame], dash: Dash):
-  df_message_ngrams = ngrams_outputs[OUTPUT_MESSAGE_NGRAMS]
-  df_ngrams = ngrams_outputs[OUTPUT_NGRAM_DEFS]
-  df_message_authors = ngrams_outputs[OUTPUT_MESSAGE_AUTHORS]
-
-  df_ngram_total_reps = (
-    df_message_ngrams
-      .group_by(COL_NGRAM_ID)
-      .agg(pl.sum(COL_MESSAGE_NGRAM_COUNT).alias("total_reps"))
+def factory(context: WebPresenterContext):
+  df = pl.read_parquet(
+    context.dependency(ngram_stats).table(
+      OUTPUT_NGRAM_STATS
+    ).parquet_path
   )
 
-  df_ngram_distinct_posters = (
-    df_message_ngrams.join(df_message_authors, on=COL_MESSAGE_ID)
-      .group_by(COL_NGRAM_ID)
-      .agg(pl.n_unique(COL_AUTHOR_ID).alias("poster_count"))
-  )
-
-  df_ngram_summary = (
-    df_ngrams
-      .join(df_ngram_total_reps, on=COL_NGRAM_ID)
-      .join(df_ngram_distinct_posters, on=COL_NGRAM_ID, how="left")
-      .select(
-        COL_NGRAM_ID,
-        COL_NGRAM_WORDS,
-        COL_NGRAM_LENGTH,
-        "total_reps",
-        "poster_count"
-      ).sort(by="total_reps", descending=True)
-  )
-
-  df = df_ngram_summary
   fig = px.scatter(
-    x=df["poster_count"],
-    y=df["total_reps"],
+    x=df[COL_NGRAM_DISTINCT_POSTER_COUNT],
+    y=df[COL_NGRAM_TOTAL_REPS],
     labels={"x": "Poster Count", "y": "Total Repetitions"},
     title="Poster Count vs. Total Reps",
   )
@@ -59,10 +33,8 @@ def factory(ngrams_outputs: dict[str, pl.DataFrame], dash: Dash):
     customdata=df[COL_NGRAM_WORDS]
   )
 
-  dash.layout = Div([
+  context.dash_app.layout = Div([
     H2("N-gram repetition statistics"),
     P("Higher points are more-repeated. Higher points to the left are repeated by fewer posters."),
     Graph(id="scatter-plot", figure=fig)
   ])
-
-  return dash

--- a/analyzers/ngram_web/interface.py
+++ b/analyzers/ngram_web/interface.py
@@ -1,11 +1,13 @@
 from analyzer_interface import WebPresenterInterface
 
 from ..ngrams import interface as ngrams_interface
+from ..ngram_stats import interface as ngram_stats_interface
 
 interface = WebPresenterInterface(
   id="ngram_repetition_by_poster",
   version="0.1.0",
   name="Repetition By Poster",
   short_description="",
-  base_analyzer=ngrams_interface
+  base_analyzer=ngrams_interface,
+  depends_on=[ngram_stats_interface]
 )

--- a/analyzers/ngrams/__init__.py
+++ b/analyzers/ngrams/__init__.py
@@ -1,4 +1,4 @@
-from analyzer_interface.interface import AnalyzerDeclaration
+from analyzer_interface import AnalyzerDeclaration
 
 from .interface import interface
 from .main import main

--- a/analyzers/temporal/__init__.py
+++ b/analyzers/temporal/__init__.py
@@ -1,4 +1,4 @@
-from analyzer_interface.interface import AnalyzerDeclaration
+from analyzer_interface import AnalyzerDeclaration
 
 from .interface import interface
 from .main import main

--- a/analyzers/temporal_barplot/factory.py
+++ b/analyzers/temporal_barplot/factory.py
@@ -1,8 +1,9 @@
 import plotly.express as px
 import polars as pl
-from dash import Dash
 from dash.dcc import Graph
 from dash.html import H2, Div, P
+
+from analyzer_interface.context import WebPresenterContext
 
 from ..temporal.interface import (OUTPUT_COL_POST_COUNT,
                                   OUTPUT_COL_TIME_INTERVAL_END,
@@ -10,8 +11,10 @@ from ..temporal.interface import (OUTPUT_COL_POST_COUNT,
                                   OUTPUT_TABLE_INTERVAL_COUNT)
 
 
-def factory(temporal_outputs: dict[str, pl.DataFrame], dash: Dash):
-  df_interval_count = temporal_outputs[OUTPUT_TABLE_INTERVAL_COUNT]
+def factory(context: WebPresenterContext):
+  df_interval_count = pl.read_parquet(
+    context.base.table(OUTPUT_TABLE_INTERVAL_COUNT).parquet_path
+  )
 
   fig = px.bar(
     x=(
@@ -25,7 +28,7 @@ def factory(temporal_outputs: dict[str, pl.DataFrame], dash: Dash):
     labels={"x": "Time Interval", "y": "Post Count"},
   )
 
-  dash.layout = Div([
+  context.dash_app.layout = Div([
     H2("Time Frequency Analysis"),
     P("The bars indicate the number of posts in each time interval."),
     Graph(id="bar-plot", figure=fig)

--- a/analyzers/time_coordination/__init__.py
+++ b/analyzers/time_coordination/__init__.py
@@ -1,4 +1,4 @@
-from analyzer_interface.interface import AnalyzerDeclaration
+from analyzer_interface import AnalyzerDeclaration
 
 from .interface import interface
 from .main import main

--- a/components/analysis_main.py
+++ b/components/analysis_main.py
@@ -1,15 +1,14 @@
 from analyzer_interface import AnalyzerInterface
-from storage import Storage
+from storage import Project, Storage
 from terminal_tools import (draw_box, open_directory_explorer, prompts,
                             wait_for_key)
 from terminal_tools.inception import TerminalContext
 
 from .analysis_web_server import analysis_web_server
 from .export_outputs import export_outputs
-from .utils import ProjectInstance
 
 
-def analysis_main(context: TerminalContext, storage: Storage, project: ProjectInstance, analyzer: AnalyzerInterface):
+def analysis_main(context: TerminalContext, storage: Storage, project: Project, analyzer: AnalyzerInterface):
   while True:
     with context.nest(draw_box(f"Analysis: {analyzer.name}", padding_lines=0)):
       action = prompts.list_input(

--- a/components/export_outputs.py
+++ b/components/export_outputs.py
@@ -7,15 +7,12 @@ from pydantic import BaseModel
 from analyzer_interface import (AnalyzerInterface, AnalyzerOutput,
                                 SecondaryAnalyzerInterface)
 from analyzers import suite
-from storage import Storage, SupportedOutputExtension
-from terminal_tools import (open_directory_explorer, prompts,
-                            wait_for_key)
+from storage import Project, Storage, SupportedOutputExtension
+from terminal_tools import open_directory_explorer, prompts, wait_for_key
 from terminal_tools.inception import TerminalContext
 
-from .utils import ProjectInstance
 
-
-def export_outputs(context: TerminalContext, storage: Storage, project: ProjectInstance, analyzer: AnalyzerInterface, *, all=False):
+def export_outputs(context: TerminalContext, storage: Storage, project: Project, analyzer: AnalyzerInterface, *, all=False):
   with context.nest("[Export Output]\n\n") as scope:
     outputs = sorted(
       get_all_outputs(storage, project, analyzer),
@@ -59,7 +56,7 @@ def export_outputs(context: TerminalContext, storage: Storage, project: ProjectI
                             selected_outputs, format)
 
 
-def export_outputs_sequence(storage: Storage, project: ProjectInstance, analyzer: AnalyzerInterface, selected_outputs: list["Output"], format: SupportedOutputExtension):
+def export_outputs_sequence(storage: Storage, project: Project, analyzer: AnalyzerInterface, selected_outputs: list["Output"], format: SupportedOutputExtension):
   print("Beginning export...")
   for selected_output in selected_outputs:
     exported_path = selected_output.export(
@@ -96,14 +93,14 @@ def export_format_prompt():
   )
 
 
-def get_all_outputs(storage: Storage, project: ProjectInstance, analyzer: AnalyzerInterface):
+def get_all_outputs(storage: Storage, project: Project, analyzer: AnalyzerInterface):
   return [
     *(Output(output=output, secondary=None)
       for output in analyzer.outputs),
     *(
       Output(output=output, secondary=secondary)
       for secondary_id in storage.list_project_secondary_analyses(project.id, analyzer.id)
-      if (secondary := suite.get_secondary_analyzer(analyzer.id, secondary_id)) is not None
+      if (secondary := suite.get_secondary_analyzer_by_id(analyzer.id, secondary_id)) is not None
       for output in secondary.outputs
     )
   ]

--- a/components/project_main.py
+++ b/components/project_main.py
@@ -1,14 +1,13 @@
-from storage import Storage
+from storage import Storage, Project
 from terminal_tools import draw_box, prompts
 from terminal_tools.inception import TerminalContext
 
 from .analysis_main import analysis_main
 from .new_analysis import new_analysis
 from .select_analysis import select_analysis
-from .utils import ProjectInstance
 
 
-def project_main(context: TerminalContext, storage: Storage, project: ProjectInstance):
+def project_main(context: TerminalContext, storage: Storage, project: Project):
   while True:
     with context.nest(draw_box(f"CIB Mango Tree/Dataset: {project.display_name}", padding_lines=0)):
       action = prompts.list_input(

--- a/components/select_analysis.py
+++ b/components/select_analysis.py
@@ -2,14 +2,12 @@ from typing import Optional
 
 from analyzer_interface import AnalyzerDeclaration
 from analyzers import suite
-from storage import Storage
+from storage import Storage, Project
 from terminal_tools import prompts, wait_for_key
 from terminal_tools.inception import TerminalContext
 
-from .utils import ProjectInstance
 
-
-def select_analysis(context: TerminalContext, storage: Storage, project: ProjectInstance):
+def select_analysis(context: TerminalContext, storage: Storage, project: Project):
   analysis_options: Optional[tuple[str, AnalyzerDeclaration]] = sorted(
     [
       (analyzer.name, analyzer)

--- a/components/select_project.py
+++ b/components/select_project.py
@@ -1,8 +1,8 @@
-from storage import Storage
+from storage import Storage, Project
 from terminal_tools import draw_box, prompts, wait_for_key
 from terminal_tools.inception import TerminalContext
 
-from .utils import ProjectInstance, input_preview
+from .utils import input_preview
 
 
 def select_project(context: TerminalContext, storage: Storage):
@@ -26,12 +26,12 @@ def select_project(context: TerminalContext, storage: Storage):
         return None
 
     with context.nest(draw_box(f"Project: {project.display_name}", padding_lines=0)):
-      df = storage.load_project_input(project.id)
-      input_preview(df)
+      df = storage.load_project_input(project.id, n_records=100)
+      table_stats = storage.get_project_input_stats(project.id)
+      input_preview(df, table_stats)
       confirm_load = prompts.confirm("Load this project?", default=True)
       if confirm_load:
-        return ProjectInstance(
+        return Project(
           id=project.id,
-          display_name=project.display_name,
-          input=df
+          display_name=project.display_name
         )

--- a/context/__init__.py
+++ b/context/__init__.py
@@ -1,0 +1,259 @@
+from functools import cached_property
+
+import polars as pl
+from dash import Dash
+from pydantic import BaseModel
+
+from analyzer_interface import (AnalyzerInterface, SecondaryAnalyzerInterface,
+                                WebPresenterInterface)
+from analyzer_interface.context import (PrimaryAnalyzerContext as BasePrimaryAnalyzerContext,
+                                        SecondaryAnalyzerContext as BaseSecondaryAnalyzerContext,
+                                        InputTableReader, AssetsReader,
+                                        TableReader, TableWriter,
+                                        WebPresenterContext as BaseWebPresenterContext)
+from preprocessing.series_semantic import SeriesSemantic
+from storage import Storage
+import os
+
+
+class PrimaryAnalyzerContext(BasePrimaryAnalyzerContext):
+  project_id: str
+  primary_analyzer: AnalyzerInterface
+  store: Storage
+  input_columns: dict[str, "InputColumnProvider"]
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  def input(self) -> InputTableReader:
+    return PrimaryAnalyzerInputTableReader(
+      project_id=self.project_id,
+      analyzer=self.primary_analyzer,
+      store=self.store,
+      input_columns=self.input_columns
+    )
+
+  def output(self, output_id: str) -> TableWriter:
+    return PrimaryAnalyzerOutputWriter(
+      project_id=self.project_id,
+      analyzer=self.primary_analyzer,
+      output_id=output_id,
+      store=self.store
+    )
+
+  def prepare(self):
+    os.makedirs(
+      self.store._get_project_primary_output_root_path(
+        self.project_id, self.primary_analyzer.id
+      ),
+      exist_ok=True
+    )
+
+
+class InputColumnProvider(BaseModel):
+  user_column_name: str
+  semantic: SeriesSemantic
+
+
+class PrimaryAnalyzerOutputWriter(TableWriter, BaseModel):
+  project_id: str
+  analyzer: AnalyzerInterface
+  output_id: str
+  store: Storage
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  @cached_property
+  def parquet_path(self):
+    return self.store.get_primary_output_parquet_path(self.project_id, self.analyzer.id, self.output_id)
+
+
+class PrimaryAnalyzerInputTableReader(InputTableReader, BaseModel):
+  project_id: str
+  analyzer: AnalyzerInterface
+  store: Storage
+  input_columns: dict[str, InputColumnProvider]
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  @cached_property
+  def parquet_path(self):
+    return self.store._get_project_input_path(self.project_id)
+
+  def preprocess(self, df: pl.DataFrame) -> pl.DataFrame:
+    return df.select([
+      pl.col(provider.user_column_name)
+        .map_batches(provider.semantic.try_convert)
+        .alias(input_column_name)
+      for input_column_name, provider in self.input_columns.items()
+    ])
+
+
+class SecondaryAnalyzerContext(BaseSecondaryAnalyzerContext):
+  project_id: str
+  primary_analyzer: AnalyzerInterface
+  secondary_analyzer: SecondaryAnalyzerInterface
+  store: Storage
+  temp_dir: str
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  @cached_property
+  def base(self) -> AssetsReader:
+    base_analyzer = self.secondary_analyzer.base_analyzer
+
+    return PrimaryAnalyzerOutputReaderGroupContext(
+      project_id=self.project_id,
+      analyzer=base_analyzer,
+      store=self.store
+    )
+
+  def dependency(self, interface: SecondaryAnalyzerInterface) -> AssetsReader:
+    return SecondaryAnalyzerOutputReaderGroupContext(
+      project_id=self.project_id,
+      primary_analyzer=self.primary_analyzer,
+      secondary_analyzer=interface,
+      store=self.store
+    )
+
+  def temp_dir(self) -> str:
+    return self.temp_dir
+
+  def output(self, output_id: str) -> TableWriter:
+    return SecondaryAnalyzerOutputWriter(
+      project_id=self.project_id,
+      primary_analyzer=self.primary_analyzer,
+      secondary_analyzer=self.secondary_analyzer,
+      output_id=output_id,
+      store=self.store
+    )
+
+  def prepare(self):
+    os.makedirs(
+      self.store._get_project_secondary_output_root_path(
+        self.project_id, self.primary_analyzer.id, self.secondary_analyzer.id,
+      ),
+      exist_ok=True
+    )
+
+
+class WebPresenterContext(BaseWebPresenterContext):
+  project_id: str
+  primary_analyzer: AnalyzerInterface
+  web_presenter: WebPresenterInterface
+  store: Storage
+  dash_app: Dash
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  @cached_property
+  def base(self) -> AssetsReader:
+    return PrimaryAnalyzerOutputReaderGroupContext(
+      project_id=self.project_id,
+      analyzer=self.primary_analyzer,
+      store=self.store
+    )
+
+  def dependency(self, interface: SecondaryAnalyzerInterface) -> AssetsReader:
+    return SecondaryAnalyzerOutputReaderGroupContext(
+      project_id=self.project_id,
+      primary_analyzer=self.primary_analyzer,
+      secondary_analyzer=interface,
+      store=self.store
+    )
+
+  @cached_property
+  def state_dir(self) -> str:
+    return self.store.get_web_presenter_state_path(
+      self.project_id, self.primary_analyzer.id, self.web_presenter.id
+    )
+
+
+class PrimaryAnalyzerOutputReaderGroupContext(AssetsReader, BaseModel):
+  analyzer: AnalyzerInterface
+  project_id: str
+  store: Storage
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  def table(self, output_id: str) -> TableReader:
+    return PrimaryAnalyzerOutputTableReader(
+      project_id=self.project_id,
+      analyzer=self.analyzer,
+      output_id=output_id,
+      store=self.store
+    )
+
+
+class PrimaryAnalyzerOutputTableReader(TableReader, BaseModel):
+  project_id: str
+  analyzer: AnalyzerInterface
+  output_id: str
+  store: Storage
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  @cached_property
+  def parquet_path(self):
+    return self.store.get_primary_output_parquet_path(self.project_id, self.analyzer.id, self.output_id)
+
+
+class SecondaryAnalyzerOutputReaderGroupContext(AssetsReader, BaseModel):
+  project_id: str
+  primary_analyzer: AnalyzerInterface
+  secondary_analyzer: SecondaryAnalyzerInterface
+  store: Storage
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  def table(self, output_id: str) -> TableReader:
+    return SecondaryAnalyzerOutputTableReader(
+      project_id=self.project_id,
+      primary_analyzer=self.primary_analyzer,
+      secondary_analyzer=self.secondary_analyzer,
+      output_id=output_id,
+      store=self.store
+    )
+
+
+class SecondaryAnalyzerOutputTableReader(TableReader, BaseModel):
+  project_id: str
+  primary_analyzer: AnalyzerInterface
+  secondary_analyzer: SecondaryAnalyzerInterface
+  output_id: str
+  store: Storage
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  @cached_property
+  def parquet_path(self):
+    return self.store.get_secondary_output_parquet_path(
+      self.project_id, self.primary_analyzer.id,
+      self.secondary_analyzer.id, self.output_id
+    )
+
+
+class SecondaryAnalyzerOutputWriter(TableWriter, BaseModel):
+  project_id: str
+  primary_analyzer: AnalyzerInterface
+  secondary_analyzer: SecondaryAnalyzerInterface
+  output_id: str
+  store: Storage
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  @cached_property
+  def parquet_path(self):
+    return self.store.get_secondary_output_parquet_path(
+      self.project_id, self.primary_analyzer.id,
+      self.secondary_analyzer.id, self.output_id
+    )

--- a/importing/__init__.py
+++ b/importing/__init__.py
@@ -1,0 +1,6 @@
+from .importer import Importer, IImporterPreload
+from .csv import CSVImporter
+
+importers: list[Importer[IImporterPreload]] = [
+  CSVImporter()
+]

--- a/importing/csv.py
+++ b/importing/csv.py
@@ -1,0 +1,53 @@
+from csv import Sniffer, Dialect
+from typing import Any
+
+import polars as pl
+from pydantic import BaseModel
+
+from .importer import IImporterPreload, Importer
+
+
+class CSVImporter(Importer["CSVPreload"]):
+  @property
+  def name(self) -> str:
+    return "CSV"
+
+  def sniff(self, input_path: str) -> bool:
+    return input_path.endswith(".csv")
+
+  def preload(self, input_path: str, n_records: int):
+    with open(input_path, "r", encoding="utf8") as file:
+      dialect = Sniffer().sniff(file.read(65536))
+    df = pl.read_csv(
+      input_path, **self._get_csv_args(dialect), n_rows=n_records
+    )
+    print(dialect)
+    return CSVPreload(preview_df=df, dialect=dialect)
+
+  def import_data(self, input_path: str, output_path: str, preload: "CSVPreload") -> pl.DataFrame:
+    dialect: Dialect = preload.dialect
+    lazyframe = pl.scan_csv(
+      input_path, **self._get_csv_args(dialect)
+    )
+    lazyframe.sink_parquet(output_path)
+
+  @staticmethod
+  def _get_csv_args(dialect: Dialect) -> dict[str, str]:
+    return {
+      "separator": dialect.delimiter,
+      "quote_char": dialect.quotechar,
+      "ignore_errors": True,
+      "has_header": True,
+      "truncate_ragged_lines": True,
+    }
+
+
+class CSVPreload(IImporterPreload, BaseModel):
+  preview_df: pl.DataFrame
+  dialect: Any
+
+  class Config:
+    arbitrary_types_allowed = True
+
+  def get_preview_dataframe(self) -> pl.DataFrame:
+    return self.preview_df

--- a/importing/importer.py
+++ b/importing/importer.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from typing import Optional, TypeVar
+
+import polars as pl
+
+
+class IImporterPreload(ABC):
+  @abstractmethod
+  def get_preview_dataframe(self) -> pl.DataFrame:
+    pass
+
+
+PreviewType = TypeVar("PreviewType", bound=IImporterPreload)
+
+
+class Importer[PreviewType](ABC):
+  @property
+  @abstractmethod
+  def name(self) -> str:
+    pass
+
+  @abstractmethod
+  def sniff(self, input_path: str) -> bool:
+    pass
+
+  @abstractmethod
+  def preload(self, input_path: str, n_records: int) -> Optional[PreviewType]:
+    pass
+
+  @abstractmethod
+  def import_data(self, input_path: str, output_path: str, preview: PreviewType) -> None:
+    pass

--- a/terminal_tools/utils.py
+++ b/terminal_tools/utils.py
@@ -158,13 +158,13 @@ def print_ascii_table(rows: list[list[str]], *, header: list[str], min_widths: l
   # Print the header
   header_row = (
     "│ " +
-    " │ ".join(
+    " ┆ ".join(
       f"{header[i]:<{col_widths[i]}}" for i, _ in enumerate(header)) +
     " │"
   )
 
-  def border_row(left: str, middle: str, right: str):
-    return left + middle.join("─" * w for w in col_widths) + right
+  def border_row(left: str, middle: str, right: str, char: str = "─"):
+    return left + middle.join(char * w for w in col_widths) + right
 
   # top border
   print(border_row("┌─", "─┬─", "─┐"))
@@ -172,13 +172,13 @@ def print_ascii_table(rows: list[list[str]], *, header: list[str], min_widths: l
   print(header_row)
 
   # separator
-  print(border_row("├─", "─┼─", "─┤"))
+  print(border_row("╞═", "═╪═", "═╡", "═"))
 
   # Print each row of data
   for row in rows:
     print(
       "│ " +
-      " │ ".join(
+      " ┆ ".join(
         f"{str(row[i]):<{col_widths[i]}}" for i, _ in enumerate(header)) +
       " │"
     )


### PR DESCRIPTION
This commit overhauls the interface between analyzer modules to remove the dependency on in-memory data, allowing for more flexible input/output handling.

- Previously, analyzer functions operated with Polars DataFrames as input/output, which constrained analysis to in-memory operations.
- This refactor introduces analysis contexts, enabling modules to load, scan, stream files, or write output in chunks, as well as use temporary directories as needed.
- The new design allows analyzer-specific handling of larger-than-memory datasets.
- Parquet remains the standard data exchange format between analyzers.
- Current utility functions still rely on Polars DataFrame/LazyFrame, but the system is capable of supporting Pandas if needed. However, this has not been implemented as all analyzers currently use Polars.
- Secondary analyzers and web presenters can now depend on other secondary analyzers. This allows us to de-duplicate logic where the same kind of calculation is needed to produce tables that are both exported and shown in the web dashboard.
- The refactor introduces some verbosity due to added IO logic, but this is necessary for future optimization and handling of large datasets across analyzers.

This change sets up the foundation for more scalable analysis workflows moving forward.

The above also allows for a snappier data import flow because we no longer need to load in the data fully. Specifically, CSV import now uses CSV scanning, which is easier on the RAM.

A couple of cosmetic touch-ups of the table renderer are included.