### PR TITLE
feat: 🎸 hide internal ngram outputs

### DIFF
--- a/analyzer_interface/interface.py
+++ b/analyzer_interface/interface.py
@@ -51,6 +51,8 @@ class AnalyzerOutput(BaseModel):
 
   columns: list["OutputColumn"]
 
+  internal: bool = False
+
   def get_column_by_name(self, name: str):
     for column in self.columns:
       if column.name == name:

--- a/analyzers/ngrams/interface.py
+++ b/analyzers/ngrams/interface.py
@@ -65,6 +65,7 @@ the corpus of text, and whether certain authors use these sequences more often.
     AnalyzerOutput(
       id=OUTPUT_MESSAGE_NGRAMS,
       name="N-gram count per message",
+      internal=True,
       columns=[
         OutputColumn(name=COL_MESSAGE_SURROGATE_ID, data_type="identifier"),
         OutputColumn(name=COL_NGRAM_ID, data_type="identifier"),
@@ -74,6 +75,7 @@ the corpus of text, and whether certain authors use these sequences more often.
     AnalyzerOutput(
       id=OUTPUT_NGRAM_DEFS,
       name="N-gram definitions",
+      internal=True,
       description="The word compositions of each unique n-gram",
       columns=[
         OutputColumn(name=COL_NGRAM_ID, data_type="identifier"),
@@ -84,6 +86,7 @@ the corpus of text, and whether certain authors use these sequences more often.
     AnalyzerOutput(
       id=OUTPUT_MESSAGE,
       name="Message data",
+      internal=True,
       description="The original message data",
       columns=[
         OutputColumn(name=COL_MESSAGE_SURROGATE_ID, data_type="identifier"),

--- a/components/new_analysis.py
+++ b/components/new_analysis.py
@@ -12,7 +12,7 @@ from terminal_tools import draw_box, print_ascii_table, prompts, wait_for_key
 from terminal_tools.inception import TerminalContext
 
 from .export_outputs import (export_format_prompt, export_outputs_sequence,
-                             get_all_outputs)
+                             get_all_exportable_outputs)
 from .utils import get_user_columns
 import tempfile
 from traceback import format_exc
@@ -198,7 +198,7 @@ def new_analysis(context: TerminalContext, storage: Storage, project: Project):
             secondary.entry_point(secondary_context)
 
         run_scope.refresh()
-        outputs = get_all_outputs(storage, project, analyzer)
+        outputs = get_all_exportable_outputs(storage, project, analyzer)
         print("The test is complete.")
         print("")
         print("You now have the option to export the following outputs:")


### PR DESCRIPTION
This PR hides intermediate outputs from ngram tests so that they are not available for export. These intermediate outputs are needed for secondary analyzers and are not of interest to the end user.