### PR TITLE
Bug: Include military time for semantic infer

### DIFF
--- a/preprocessing/series_semantic.py
+++ b/preprocessing/series_semantic.py
@@ -34,12 +34,12 @@ class SeriesSemantic(BaseModel):
         return self.column_type(series.dtype)
 
 
-def parse_time_flexible(s: pl.Series) -> pl.Series:
+def parse_time_military(s: pl.Series) -> pl.Series:
     """Parse time strings with multiple format attempts"""
     # Try different time formats
-    formats_to_try = ["%H:%M:%S", "%H:%M", "%I:%M:%S %p", "%I:%M %p"]
+    FORMATS_TO_TRY = ["%H:%M:%S", "%H:%M", "%I:%M:%S %p", "%I:%M %p"]
 
-    for fmt in formats_to_try:
+    for fmt in FORMATS_TO_TRY:
         try:
             result = s.str.strptime(pl.Time, format=fmt, strict=False)
             if result.is_not_null().sum() > 0:  # If any parsed successfully
@@ -114,10 +114,10 @@ native_datetime = SeriesSemantic(
     data_type="datetime",
 )
 
-time_flexible = SeriesSemantic(
-    semantic_name="time_flexible",
+time_military = SeriesSemantic(
+    semantic_name="time_military",
     column_type=pl.String,
-    try_convert=parse_time_flexible,
+    try_convert=parse_time_military,
     validate_result=lambda s: s.is_not_null(),
     data_type="datetime",
 )
@@ -213,10 +213,10 @@ boolean_catch_all = SeriesSemantic(
 all_semantics = [
     native_datetime,
     native_date,
-    time_flexible,
     datetime_string,
     date_string,
     time_string,
+    time_military,
     timestamp_seconds,
     timestamp_milliseconds,
     url,

--- a/preprocessing/series_semantic.py
+++ b/preprocessing/series_semantic.py
@@ -16,7 +16,6 @@ class SeriesSemantic(BaseModel):
     data_type: DataType
 
     def check(self, series: pl.Series, threshold: float = 0.8, sample_size: int = 100):
-        
         if not self.check_type(series):
             return False
 
@@ -28,7 +27,6 @@ class SeriesSemantic(BaseModel):
         except Exception:
             return False
         return self.validate_result(result).sum() / sample.len() > threshold
-
 
     def check_type(self, series: pl.Series):
         if isinstance(self.column_type, type):
@@ -114,7 +112,7 @@ native_datetime = SeriesSemantic(
     data_type="datetime",
 )
 
-native_time = SeriesSemantic(
+time_flexible = SeriesSemantic(
     semantic_name = "time_flexible", 
     column_type=pl.String,
     try_convert=parse_time_flexible,
@@ -213,7 +211,7 @@ boolean_catch_all = SeriesSemantic(
 all_semantics = [
     native_datetime,
     native_date,
-    native_time,
+    time_flexible,
     datetime_string,
     date_string,
     time_string,

--- a/preprocessing/series_semantic.py
+++ b/preprocessing/series_semantic.py
@@ -16,20 +16,16 @@ class SeriesSemantic(BaseModel):
     data_type: DataType
 
     def check(self, series: pl.Series, threshold: float = 0.8, sample_size: int = 100):
-        print(f"🔍 Checking semantic '{self.semantic_name}' for series with dtype: {series.dtype}")
         
         if not self.check_type(series):
-            print(f"❌ '{self.semantic_name}' failed type check")
             return False
 
         sample = sample_series(series, sample_size)
         try:
             if not self.prevalidate(sample):
-                print(f"❌ '{self.semantic_name}' failed prevalidation")
                 return False
             result = self.try_convert(sample)
         except Exception:
-            print(f"❌ '{self.semantic_name}' failed conversion: {e}")
             return False
         return self.validate_result(result).sum() / sample.len() > threshold
 
@@ -235,16 +231,11 @@ all_semantics = [
 def infer_series_semantic(
     series: pl.Series, *, threshold: float = 0.8, sample_size=100
 ):
-    print(f"\n🚀 Starting semantic inference for series '{series.name}' with {series.len()} rows")
-    print(f"   Column dtype: {series.dtype}")
-    print(f"   Sample values: {series.head(3).to_list()}")
     
     for semantic in all_semantics:
         if semantic.check(series, threshold=threshold, sample_size=sample_size):
-            print(f"🎯 MATCH FOUND: '{semantic.semantic_name}' -> data_type: '{semantic.data_type}'\n")
             return semantic
     
-    print("💀 NO SEMANTIC MATCH FOUND\n")
     return None
 
 

--- a/preprocessing/series_semantic.py
+++ b/preprocessing/series_semantic.py
@@ -229,11 +229,9 @@ all_semantics = [
 def infer_series_semantic(
     series: pl.Series, *, threshold: float = 0.8, sample_size=100
 ):
-    
     for semantic in all_semantics:
         if semantic.check(series, threshold=threshold, sample_size=sample_size):
             return semantic
-    
     return None
 
 

--- a/preprocessing/series_semantic.py
+++ b/preprocessing/series_semantic.py
@@ -32,12 +32,13 @@ class SeriesSemantic(BaseModel):
         if isinstance(self.column_type, type):
             return isinstance(series.dtype, self.column_type)
         return self.column_type(series.dtype)
-    
+
+
 def parse_time_flexible(s: pl.Series) -> pl.Series:
     """Parse time strings with multiple format attempts"""
     # Try different time formats
     formats_to_try = ["%H:%M:%S", "%H:%M", "%I:%M:%S %p", "%I:%M %p"]
-    
+
     for fmt in formats_to_try:
         try:
             result = s.str.strptime(pl.Time, format=fmt, strict=False)
@@ -45,9 +46,10 @@ def parse_time_flexible(s: pl.Series) -> pl.Series:
                 return result
         except:
             continue
-    
+
     # If all formats fail, return nulls
     return pl.Series([None] * s.len(), dtype=pl.Time)
+
 
 def parse_datetime_with_tz(s: pl.Series) -> pl.Series:
     """Parse datetime strings with timezone info (both abbreviations and offsets)"""
@@ -113,11 +115,11 @@ native_datetime = SeriesSemantic(
 )
 
 time_flexible = SeriesSemantic(
-    semantic_name = "time_flexible", 
+    semantic_name="time_flexible",
     column_type=pl.String,
     try_convert=parse_time_flexible,
     validate_result=lambda s: s.is_not_null(),
-    data_type="datetime"
+    data_type="datetime",
 )
 
 datetime_string = SeriesSemantic(

--- a/preprocessing/test_series_semantic.py
+++ b/preprocessing/test_series_semantic.py
@@ -122,6 +122,7 @@ def test_parse_datetime_with_tz():
     assert result.dtype == pl.Datetime
     assert result.is_not_null().all()
 
+
 def test_parse_time_military():
     """Test military time parsing function with various formats"""
     # Test 24-hour format without seconds (HH:MM)
@@ -135,6 +136,7 @@ def test_parse_time_military():
     result = parse_time_military(series_24h_sec)
     assert result.dtype == pl.Time
     assert result.is_not_null().all()
+
 
 def test_parse_datetime_with_tz_no_timezone():
     """Test datetime parsing without timezone suffix"""
@@ -208,6 +210,7 @@ def test_time_military_semantic_inference():
     assert semantic is not None
     assert semantic.semantic_name == "time_military"
     assert semantic.data_type == "datetime"
+
 
 # Edge cases
 def test_all_none_series():

--- a/preprocessing/test_series_semantic.py
+++ b/preprocessing/test_series_semantic.py
@@ -209,21 +209,6 @@ def test_time_military_semantic_inference():
     assert semantic.semantic_name == "time_military"
     assert semantic.data_type == "datetime"
 
-    # Test 12-hour format detection  
-    series_12h = pl.Series(["2:30 PM", "11:45 AM", "12:00 PM", "1:15 AM", "6:30 PM"])
-    semantic = infer_series_semantic(series_12h)
-    assert semantic is not None
-    assert semantic.semantic_name == "time_military"
-    assert semantic.data_type == "datetime"
-
-    # Test mixed format detection (should still work)
-    series_mixed = pl.Series(["14:30", "2:45 PM", "23:59", "11:30 AM", "00:15"])
-    semantic = infer_series_semantic(series_mixed)
-    assert semantic is not None
-    assert semantic.semantic_name == "time_military" 
-    assert semantic.data_type == "datetime"
-
-
 # Edge cases
 def test_all_none_series():
     """Test series with all null values"""

--- a/preprocessing/test_series_semantic.py
+++ b/preprocessing/test_series_semantic.py
@@ -9,6 +9,7 @@ from preprocessing.series_semantic import (
     native_date,
     native_datetime,
     parse_datetime_with_tz,
+    parse_time_military,
     text_catch_all,
     time_string,
 )
@@ -121,6 +122,19 @@ def test_parse_datetime_with_tz():
     assert result.dtype == pl.Datetime
     assert result.is_not_null().all()
 
+def test_parse_time_military():
+    """Test military time parsing function with various formats"""
+    # Test 24-hour format without seconds (HH:MM)
+    series_24h = pl.Series(["23:39", "12:45", "00:30"])
+    result = parse_time_military(series_24h)
+    assert result.dtype == pl.Time
+    assert result.is_not_null().all()
+
+    # Test 24-hour format with seconds (HH:MM:SS)
+    series_24h_sec = pl.Series(["14:30:15", "09:15:30", "23:59:59"])
+    result = parse_time_military(series_24h_sec)
+    assert result.dtype == pl.Time
+    assert result.is_not_null().all()
 
 def test_parse_datetime_with_tz_no_timezone():
     """Test datetime parsing without timezone suffix"""
@@ -184,6 +198,30 @@ def test_parse_datetime_mixed_timezones_warning():
     # But parsing should still work
     assert result.dtype == pl.Datetime
     assert result.is_not_null().all()
+
+
+def test_time_military_semantic_inference():
+    """Test that time_military semantic gets properly detected"""
+    # Test 24-hour format detection
+    series_24h = pl.Series(["23:47", "14:30", "09:15", "00:00", "12:45"])
+    semantic = infer_series_semantic(series_24h)
+    assert semantic is not None
+    assert semantic.semantic_name == "time_military"
+    assert semantic.data_type == "datetime"
+
+    # Test 12-hour format detection  
+    series_12h = pl.Series(["2:30 PM", "11:45 AM", "12:00 PM", "1:15 AM", "6:30 PM"])
+    semantic = infer_series_semantic(series_12h)
+    assert semantic is not None
+    assert semantic.semantic_name == "time_military"
+    assert semantic.data_type == "datetime"
+
+    # Test mixed format detection (should still work)
+    series_mixed = pl.Series(["14:30", "2:45 PM", "23:59", "11:30 AM", "00:15"])
+    semantic = infer_series_semantic(series_mixed)
+    assert semantic is not None
+    assert semantic.semantic_name == "time_military" 
+    assert semantic.data_type == "datetime"
 
 
 # Edge cases


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, the CLI has trouble recognizing 24 hour/military time format. Included in this PR is a new series_Semantic case along with a parsing function to handle flexible time formats.

## What is the new behavior?

The time type will be recognized and parsed. This is a subissue ([Issue 265](https://github.com/civictechdc/mango-tango-cli/issues/265)) of [Issue 249](https://github.com/civictechdc/mango-tango-cli/issues/249) and is the first step in updating the CLI so that it can handle separate columns.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No