### PR TITLE
fix: remove the test step it prevewi_build_gui workflow

### DIFF
--- a/.github/workflows/build_preview_gui.yml
+++ b/.github/workflows/build_preview_gui.yml
@@ -99,18 +99,6 @@ jobs:
             cd dist && zip -r "CIBMangoTree_${ARTIFACT_NAME}-${VERSION}-${SHA}.zip" CIBMangoTree.app
           fi
 
-      - name: Run smoke test
-        shell: bash
-        continue-on-error: true
-        run: |
-          if [ "${{ matrix.os }}" = "windows-2022" ]; then
-            echo "Running smoke test: dist\CIBMangoTree.exe --noop"
-            dist/CIBMangoTree.exe --noop || echo "⚠️ Smoke test failed or --noop not supported in GUI mode"
-          else
-            echo "Running smoke test: dist/CIBMangoTree.app/Contents/MacOS/CIBMangoTree --noop"
-            dist/CIBMangoTree.app/Contents/MacOS/CIBMangoTree --noop || echo "⚠️ Smoke test failed or --noop not supported in GUI mode"
-          fi
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `preview_build_gui` workflow seems to run correctly but hangs at the test step after launching a NiceGUI server. It should just be removed.

Issue Number: N/A

## What is the new behavior?

The workflow goes straight to uploading the artifact step.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
