### PR TITLE
Update docs to reflect new cibmangotree module name

### DIFF
--- a/.ai-context/README.md
+++ b/.ai-context/README.md
@@ -28,8 +28,8 @@ consistent UX while allowing easy contribution of new analyzers.
 
 ### Entry Points
 
-- `mangotango.py` - Main application bootstrap
-- `python -m mangotango` - Standard execution command
+- `cibmangotree.py` - Main application bootstrap
+- `python -m cibmangotree` - Standard execution command
 
 ### Core Architecture (MVC-like)
 

--- a/.ai-context/setup-guide.md
+++ b/.ai-context/setup-guide.md
@@ -58,7 +58,7 @@ The bootstrap script will:
 ### 4. Verify Installation
 
 ```bash
-python -m mangotango --noop
+python -m cibmangotree --noop
 ```
 
 Should output: "No-op flag detected. Exiting successfully."
@@ -118,7 +118,7 @@ mango-tango-cli/
 ├── storage/                # Data persistence
 ├── importing/              # Data import modules
 ├── requirements*.txt       # Dependencies
-└── mangotango.py          # Main entry point
+└── cibmangotree.py         # Main entry point
 ```
 
 ## Database and Storage Setup
@@ -149,14 +149,14 @@ source venv/bin/activate  # macOS/Linux
 venv\Scripts\activate     # Windows
 
 # Start the application
-python -m mangotango
+python -m cibmangotree
 ```
 
 ### Development Mode
 
 ```bash
 # Run with debugging/development flags
-python -m mangotango --noop  # Test mode, exits immediately
+python -m cibmangotree --noop  # Test mode, exits immediately
 ```
 
 ## Testing Setup

--- a/.ai-context/symbol-reference.md
+++ b/.ai-context/symbol-reference.md
@@ -221,7 +221,7 @@ Core tokenizer implementation with Unicode awareness:
 
 ### Main Application
 
-- `mangotango.py` - Application bootstrap and initialization
+- `cibmangotree.py` - Application bootstrap and initialization
   - `freeze_support()` - Multiprocessing setup
   - `enable_windows_ansi_support()` - Terminal color support
   - Storage initialization with app metadata
@@ -229,8 +229,8 @@ Core tokenizer implementation with Unicode awareness:
 
 ### Module Entry Point
 
-- `python -m mangotango` - Standard execution command
-- `python -m mangotango --noop` - No-operation mode for testing
+- `python -m cibmangotree` - Standard execution command
+- `python -m cibmangotree --noop` - No-operation mode for testing
 
 ## Integration Points
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -50,7 +50,7 @@ Mango Tango CLI is a Python terminal-based tool for social media data analysis w
 
 ### Key Entry Points
 
-- `mangotango.py` - Application bootstrap and initialization
+- `cibmangotree.py` - Application bootstrap and initialization
 - `app/app.py:App` - Main application controller
 - `components/main_menu.py:main_menu()` - Terminal UI entry point
 - `analyzers/__init__.py:suite` - Analyzer registry
@@ -96,15 +96,15 @@ python -m venv venv
 ./bootstrap.ps1 # Windows
 
 # Run application
-python -m mangotango
+python -m cibmangotree
 ```
 
 ## Common Commands
 
 ### Development
 
-- `python -m mangotango` - Start application
-- `python -m mangotango --noop` - Test mode
+- `python -m cibmangotree` - Start application
+- `python -m cibmangotree --noop` - Test mode
 - `isort . && black .` - Format code
 - `pytest` - Run tests
 - `pytest analyzers/[name]/` - Test specific analyzer

--- a/.serena/memories/code_structure.md
+++ b/.serena/memories/code_structure.md
@@ -2,7 +2,7 @@
 
 ## Entry Point
 
-- `mangotango.py` - Main entry point, bootstraps the application with Storage, App, and terminal components
+- `cibmangotree.py` - Main entry point, bootstraps the application with Storage, App, and terminal components
 
 ## Core Modules
 

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -15,10 +15,10 @@ python -m venv venv
 
 ```bash
 # Start the application
-python -m mangotango
+python -m cibmangotree
 
 # Run with no-op flag (for testing)
-python -m mangotango --noop
+python -m cibmangotree --noop
 ```
 
 ## Development Commands

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Debug",
       "type": "debugpy",
       "request": "launch",
-      "module": "mangotango"
+      "module": "cibmangotree"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ read_memory("task_completion_checklist") # Before committing
 
 ```markdown
 # Find app entry point
-find_symbol("main", relative_path="mangotango.py")
+find_symbol("main", relative_path="cibmangotree.py")
 
 # Explore analyzer system
 get_symbols_overview("analyzers/")
@@ -203,7 +203,7 @@ find_symbol("main_menu", include_body=True)
 
 ### Key Architecture References
 
-- **Entry Point**: `mangotango.py` - Application bootstrap
+- **Entry Point**: `cibmangotree.py` - Application bootstrap
 - **Core App**: `app/app.py:App` - Main application controller
 - **Storage**: `storage/__init__.py:Storage` - Data persistence
 - **UI Components**: `components/main_menu.py:main_menu()` - Terminal interface

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ python -m venv venv
 ### 3. Verify Installation
 
 ```bash
-python -m mangotango --noop
+python -m cibmangotree --noop
 # Should output: "No-op flag detected. Exiting successfully."
 ```
 

--- a/docs/guides/contributing/logging.md
+++ b/docs/guides/contributing/logging.md
@@ -114,13 +114,13 @@ Users can control log verbosity when running the application:
 
 ```shell
 # Default INFO level
-python -m mangotango
+python -m cibmangotree
 
 # Verbose DEBUG level for troubleshooting
-python -m mangotango --log-level DEBUG
+python -m cibmangotree --log-level DEBUG
 
 # Only show warnings and errors in log file
-python -m mangotango --log-level WARNING
+python -m cibmangotree --log-level WARNING
 ```
 
 ### Log File Management

--- a/docs/guides/get-started/installation.md
+++ b/docs/guides/get-started/installation.md
@@ -174,7 +174,7 @@ mango-tango-cli/
 ├── storage/                # Data persistence
 ├── importing/              # Data import modules
 ├── requirements*.txt       # Dependencies
-└── mangotango.py          # Main entry point
+└── cibmangotree.py         # Main entry point
 ```
 
 # Database and Storage Setup
@@ -201,14 +201,14 @@ No manual database setup required.
 
 ```bash
 # Start the application
-python -m mangotango
+python -m cibmangotree
 ```
 
 ## Development Mode
 
 ```bash
 # Run with debugging/development flags
-python -m mangotango --noop  # Test mode, exits immediately
+python -m cibmangotree --noop  # Test mode, exits immediately
 ```
 
 ## Development Mode for The React Dashboards


### PR DESCRIPTION
Update docs to reflect new cibmangotree module name, fixing suggested invocation of the app.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- ~Bugfix~
- ~Feature~
- ~Code style update (formatting, renaming)~
- ~Refactoring (no functional changes, no API changes)~
- ~Build-related changes~
- [x] Documentation content changes
- ~Other (please describe)~

## What is the current behavior?

Problem: Several getting-started docs still referred to outdated invocations of `python -m mangotango`.




Issue Number: _N/A_

## What is the new behavior?

This PR changes these doc references to `python -m cibmangotree`.


## Does this introduce a breaking change?

- ~Yes~
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->