### PR TITLE
fix: update macos intel image in GUI preview build workflow

### DIFF
--- a/.github/workflows/build_preview_gui.yml
+++ b/.github/workflows/build_preview_gui.yml
@@ -35,7 +35,7 @@ jobs:
             executable_name: CIBMangoTree.exe
           - platform_name: MacOS (x86)
             artifact_name: macos-x86
-            os: macos-13
+            os: macos-15-intel
             executable_name: CIBMangoTree.app
           - platform_name: MacOS (arm64)
             artifact_name: macos-arm64


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `.github/workflows/build_preview_gui.yaml` worfklow still contains reference [to the no longer supported macos-13 image](https://github.com/actions/runner-images/issues/13046) which causes the workflow to be cancelled.

Issue Number: N/A

## What is the new behavior?

The worfklow will run using the new image `macos-15-intel` (supported until 2027)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
