### PR TITLE
feat: use ui.stepper to navigate analyzer selection and analysis configuration in one page

### DIFF
--- a/gui/base.py
+++ b/gui/base.py
@@ -39,6 +39,7 @@ class GuiRoutes(BaseModel):
     select_analyzer_fork: str = "/select_analyzer_fork"
     select_analyzer: str = "/select_analyzer"
     select_previous_analyzer: str = "/select_previous_analyzer"
+    configure_analysis: str = "/configure_analysis"
     configure_analysis_dataset: str = "/configure_analysis_dataset"
     configure_analysis_parameters: str = "/configure_analysis_parameters"
     preview_dataset: str = "/preview_dataset"

--- a/gui/components/__init__.py
+++ b/gui/components/__init__.py
@@ -1,5 +1,11 @@
 from .analysis import AnalysisParamsCard
 from .manage_analyses import ManageAnalysisDialog
+from .stepper_steps import (
+    AnalyzerSelectionStep,
+    ColumnMappingStep,
+    ParamsConfigStep,
+    RunAnalysisStep,
+)
 from .toggle import ToggleButton, ToggleButtonGroup
 from .upload.upload_button import UploadButton
 
@@ -9,4 +15,8 @@ __all__ = [
     "AnalysisParamsCard",
     "UploadButton",
     "ManageAnalysisDialog",
+    "AnalyzerSelectionStep",
+    "ColumnMappingStep",
+    "ParamsConfigStep",
+    "RunAnalysisStep",
 ]

--- a/gui/components/stepper_steps/__init__.py
+++ b/gui/components/stepper_steps/__init__.py
@@ -1,0 +1,11 @@
+from .analyzer_step import AnalyzerSelectionStep
+from .column_mapping_step import ColumnMappingStep
+from .params_step import ParamsConfigStep
+from .run_step import RunAnalysisStep
+
+__all__ = [
+    "AnalyzerSelectionStep",
+    "ColumnMappingStep",
+    "ParamsConfigStep",
+    "RunAnalysisStep",
+]

--- a/gui/components/stepper_steps/analyzer_step.py
+++ b/gui/components/stepper_steps/analyzer_step.py
@@ -30,7 +30,7 @@ class AnalyzerSelectionStep:
             for analyzer_name in analyzer_options.keys():
                 self.button_group.add_button(analyzer_name)
 
-        with ui.card().classes("w-full no-shadow"):
+        with ui.element().classes("pt-12"):
             DEFAULT_TEXT = "No analyzer selected. Click button above to select it."
 
             ui.label().bind_text_from(

--- a/gui/components/stepper_steps/analyzer_step.py
+++ b/gui/components/stepper_steps/analyzer_step.py
@@ -1,0 +1,68 @@
+from nicegui import ui
+
+from gui.base import GuiSession
+from gui.components import ToggleButtonGroup
+
+
+class AnalyzerSelectionStep:
+    """Step 1: Select analyzer from available options."""
+
+    def __init__(self, session: GuiSession):
+        self.session = session
+        self.button_group: ToggleButtonGroup | None = None
+
+    def render(self) -> None:
+        """Render the step content."""
+        analyzers = self.session.app.context.suite.primary_anlyzers
+
+        if not analyzers:
+            ui.label("No analyzers available").classes("text-grey")
+            return
+
+        analyzer_options = {
+            analyzer.name: analyzer.short_description for analyzer in analyzers
+        }
+
+        self.button_group = ToggleButtonGroup()
+
+        with ui.row().classes("items-center justify-center gap-4"):
+            for analyzer_name in analyzer_options.keys():
+                self.button_group.add_button(analyzer_name)
+
+        with ui.card().classes("w-full no-shadow"):
+            DEFAULT_TEXT = "No analyzer selected. Click button above to select it."
+
+            ui.label().bind_text_from(
+                target_object=self.button_group,
+                target_name="selected_text",
+                backward=lambda text: analyzer_options.get(text, DEFAULT_TEXT),
+            ).classes("text-center w-full")
+
+    def is_valid(self) -> bool:
+        """Check if an analyzer is selected."""
+        return (
+            self.button_group is not None
+            and self.button_group.get_selected_text() is not None
+        )
+
+    def save_state(self) -> bool:
+        """Save selection to session. Returns True if successful."""
+        if not self.button_group:
+            return False
+
+        new_selection = self.button_group.get_selected_text()
+
+        if not new_selection:
+            return False
+
+        analyzers = self.session.app.context.suite.primary_anlyzers
+        selected_analyzer = next(
+            (a for a in analyzers if a.name == new_selection), None
+        )
+
+        if not selected_analyzer:
+            return False
+
+        self.session.selected_analyzer = selected_analyzer
+        self.session.selected_analyzer_name = new_selection
+        return True

--- a/gui/components/stepper_steps/analyzer_step.py
+++ b/gui/components/stepper_steps/analyzer_step.py
@@ -11,6 +11,7 @@ class AnalyzerSelectionStep:
         self.session = session
         self.button_group: ToggleButtonGroup | None = None
 
+    @ui.refreshable_method
     def render(self) -> None:
         """Render the step content."""
         analyzers = self.session.app.context.suite.primary_anlyzers

--- a/gui/components/stepper_steps/analyzer_step.py
+++ b/gui/components/stepper_steps/analyzer_step.py
@@ -1,7 +1,7 @@
 from nicegui import ui
 
 from gui.base import GuiSession
-from gui.components import ToggleButtonGroup
+from gui.components.toggle import ToggleButtonGroup
 
 
 class AnalyzerSelectionStep:

--- a/gui/components/stepper_steps/column_mapping_step.py
+++ b/gui/components/stepper_steps/column_mapping_step.py
@@ -1,0 +1,169 @@
+import polars as pl
+from nicegui import ui
+
+from analyzer_interface import column_automap, get_data_type_compatibility_score
+from gui.base import GuiSession
+
+
+class ColumnMappingStep:
+    """Step 2: Map user columns to analyzer input columns."""
+
+    def __init__(self, session: GuiSession):
+        self.session = session
+        self.column_dropdowns: dict = {}
+        self.preview_container = None
+
+    def render(self) -> None:
+        """Render the step content with column cards and preview."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+
+        if not analyzer or not project:
+            ui.label("No analyzer or project selected").classes("text-grey")
+            return
+
+        input_columns = analyzer.input.columns
+        user_columns = project.columns
+
+        draft_column_mapping = column_automap(user_columns, input_columns)
+
+        with (
+            ui.column()
+            .classes("w-full items-center gap-6")
+            .style("max-width: 960px; margin: 0 auto;")
+        ):
+            ui.label("Map Your Data Columns").classes("text-lg font-bold mb-4")
+
+            with ui.row().classes("flex-wrap gap-6 justify-center w-full"):
+                for input_col in input_columns:
+                    self._build_column_card(
+                        input_col, user_columns, draft_column_mapping
+                    )
+
+            self.preview_container = ui.column().classes("w-full")
+            self._update_preview()
+
+    def _build_column_card(self, input_col, user_columns, draft_column_mapping) -> None:
+        """Build a single column mapping card."""
+        with ui.card().classes("w-52 p-4 no-shadow border border-gray-200"):
+            with ui.row().classes("items-center gap-1"):
+                ui.label(input_col.human_readable_name_or_fallback()).classes(
+                    "text-bold"
+                )
+                if input_col.description:
+                    with ui.icon("info").classes("text-grey-6 cursor-pointer"):
+                        ui.tooltip(input_col.description)
+
+            compatible_columns = [
+                user_col
+                for user_col in user_columns
+                if get_data_type_compatibility_score(
+                    input_col.data_type, user_col.data_type
+                )
+                is not None
+            ]
+
+            dropdown_options = {
+                f"{user_col.name}": user_col.name for user_col in compatible_columns
+            }
+
+            default_value = None
+            if input_col.name in draft_column_mapping:
+                mapped_col_name = draft_column_mapping[input_col.name]
+                default_value = next(
+                    (k for k, v in dropdown_options.items() if v == mapped_col_name),
+                    None,
+                )
+
+            dropdown = (
+                ui.select(
+                    options=list(dropdown_options.keys()),
+                    value=default_value,
+                    on_change=lambda: self._update_preview(),
+                )
+                .classes("w-full mt-2")
+                .props("use-chips")
+            )
+
+            self.column_dropdowns[input_col.name] = (dropdown, dropdown_options)
+
+    def _build_preview_df(self) -> pl.DataFrame:
+        """Build preview DataFrame with currently mapped columns."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+
+        if not analyzer or not project:
+            return pl.DataFrame()
+
+        current_mapping = {}
+        for input_col_name, (dropdown, options) in self.column_dropdowns.items():
+            if dropdown.value:
+                current_mapping[input_col_name] = options[dropdown.value]
+
+        tmp_col = list(project.column_dict.values())[0]
+        N_PREVIEW_ROWS = min(5, tmp_col.data.len())
+
+        preview_data = {}
+        for analyzer_col in analyzer.input.columns:
+            col_name = analyzer_col.human_readable_name_or_fallback()
+            user_col_name = current_mapping.get(analyzer_col.name)
+
+            if user_col_name and user_col_name in project.column_dict:
+                user_col = project.column_dict[user_col_name]
+                preview_data[col_name] = user_col.head(
+                    N_PREVIEW_ROWS
+                ).apply_semantic_transform()
+            else:
+                preview_data[col_name] = [None] * N_PREVIEW_ROWS
+
+        return pl.DataFrame(preview_data)
+
+    def _update_preview(self) -> None:
+        """Rebuild preview when dropdown changes."""
+        if self.preview_container is None:
+            return
+
+        self.preview_container.clear()
+        with self.preview_container:
+            preview_df = self._build_preview_df()
+            preview_title = (
+                "Data Preview (first 5 rows)"
+                if len(preview_df) > 5
+                else "Data Preview (all rows)"
+            )
+            ui.label(preview_title).classes("text-sm text-grey-7")
+
+            grid = ui.aggrid.from_polars(
+                preview_df,
+                theme="quartz",
+                auto_size_columns=True,
+            ).classes("w-full h-64")
+            grid.on(
+                "firstDataRendered",
+                lambda: grid.run_grid_method("sizeColumnsToFit"),
+            )
+
+    def is_valid(self) -> bool:
+        """Check if all required columns are mapped."""
+        analyzer = self.session.selected_analyzer
+        if not analyzer:
+            return False
+
+        required_columns = [col.name for col in analyzer.input.columns]
+        mapped_columns = [
+            col_name
+            for col_name, (dropdown, _) in self.column_dropdowns.items()
+            if dropdown.value
+        ]
+
+        return all(col in mapped_columns for col in required_columns)
+
+    def save_state(self) -> bool:
+        """Save column mapping to session."""
+        final_mapping = {}
+        for input_col_name, (dropdown, options) in self.column_dropdowns.items():
+            if dropdown.value:
+                final_mapping[input_col_name] = options[dropdown.value]
+
+        self.session.column_mapping = final_mapping
+        return True

--- a/gui/components/stepper_steps/column_mapping_step.py
+++ b/gui/components/stepper_steps/column_mapping_step.py
@@ -13,13 +13,18 @@ class ColumnMappingStep:
         self.column_dropdowns: dict = {}
         self.preview_container = None
 
+    @ui.refreshable_method
     def render(self) -> None:
         """Render the step content with column cards and preview."""
         analyzer = self.session.selected_analyzer
         project = self.session.current_project
 
-        if not analyzer or not project:
-            ui.label("No analyzer or project selected").classes("text-grey")
+        if not analyzer:
+            ui.label("Please select an analyzer first").classes("text-grey")
+            return
+
+        if not project:
+            ui.label("No project selected").classes("text-grey")
             return
 
         input_columns = analyzer.input.columns

--- a/gui/components/stepper_steps/params_step.py
+++ b/gui/components/stepper_steps/params_step.py
@@ -1,0 +1,105 @@
+from tempfile import TemporaryDirectory
+
+from nicegui import ui
+
+from context import InputColumnProvider, PrimaryAnalyzerDefaultParametersContext
+from gui.base import GuiSession
+from gui.components import AnalysisParamsCard
+
+
+class ParamsConfigStep:
+    """Step 3: Configure analyzer parameters."""
+
+    def __init__(self, session: GuiSession):
+        self.session = session
+        self.params_card: AnalysisParamsCard | None = None
+        self._param_values: dict = {}
+
+    def render(self) -> None:
+        """Render parameter configuration or 'no params' message."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+        column_mapping = self.session.column_mapping
+
+        if not analyzer:
+            ui.label("No analyzer selected").classes("text-grey")
+            return
+
+        if not analyzer.params:
+            ui.label("This analyzer has no configurable parameters.").classes(
+                "text-grey-7"
+            )
+            self.session.analysis_params = {}
+            return
+
+        if not project or not column_mapping:
+            ui.label("Column mapping not configured").classes("text-grey")
+            return
+
+        with TemporaryDirectory() as temp_dir:
+            default_parameters_context = PrimaryAnalyzerDefaultParametersContext(
+                analyzer=analyzer,
+                store=self.session.app.context.storage,
+                temp_dir=temp_dir,
+                input_columns={
+                    analyzer_column_name: InputColumnProvider(
+                        user_column_name=user_column_name,
+                        semantic=project.column_dict[user_column_name].semantic,
+                    )
+                    for analyzer_column_name, user_column_name in column_mapping.items()
+                },
+            )
+
+            analyzer_decl = self.session.app.context.suite.get_primary_analyzer(
+                analyzer.id
+            )
+
+            if not analyzer_decl:
+                ui.label(f"Analyzer `{analyzer.id}` not found").classes("text-negative")
+                return
+
+            param_values = {
+                **{
+                    param_spec.id: static_param_default_value
+                    for param_spec in analyzer_decl.params
+                    if (static_param_default_value := param_spec.default) is not None
+                },
+                **analyzer_decl.default_params(default_parameters_context),
+            }
+            param_values = {
+                param_id: param_value
+                for param_id, param_value in param_values.items()
+                if param_value is not None
+            }
+
+            self._param_values = param_values
+
+        with (
+            ui.column()
+            .classes("w-full items-center gap-6")
+            .style("max-width: 960px; margin: 0 auto;")
+        ):
+            ui.label(f"Configure {analyzer.name} Parameters").classes(
+                "text-lg font-bold mb-4"
+            )
+
+            self.params_card = AnalysisParamsCard(
+                params=analyzer.params, default_values=self._param_values
+            )
+
+    def is_valid(self) -> bool:
+        """Always valid - params are optional."""
+        return True
+
+    def save_state(self) -> bool:
+        """Save params to session."""
+        if self.params_card:
+            self.session.analysis_params = self.params_card.get_param_values()
+        else:
+            self.session.analysis_params = {}
+        return True
+
+    def has_params(self) -> bool:
+        """Check if analyzer has configurable parameters."""
+        analyzer = self.session.selected_analyzer
+        return analyzer is not None and len(analyzer.params) > 0

--- a/gui/components/stepper_steps/params_step.py
+++ b/gui/components/stepper_steps/params_step.py
@@ -15,6 +15,7 @@ class ParamsConfigStep:
         self.params_card: AnalysisParamsCard | None = None
         self._param_values: dict = {}
 
+    @ui.refreshable_method
     def render(self) -> None:
         """Render parameter configuration or 'no params' message."""
         analyzer = self.session.selected_analyzer
@@ -22,7 +23,7 @@ class ParamsConfigStep:
         column_mapping = self.session.column_mapping
 
         if not analyzer:
-            ui.label("No analyzer selected").classes("text-grey")
+            ui.label("Please select an analyzer first").classes("text-grey")
             return
 
         if not analyzer.params:
@@ -33,7 +34,7 @@ class ParamsConfigStep:
             return
 
         if not project or not column_mapping:
-            ui.label("Column mapping not configured").classes("text-grey")
+            ui.label("Please map columns first").classes("text-grey")
             return
 
         with TemporaryDirectory() as temp_dir:

--- a/gui/components/stepper_steps/run_step.py
+++ b/gui/components/stepper_steps/run_step.py
@@ -25,11 +25,20 @@ class RunAnalysisStep:
         self.notify_error = notify_error
         self.navigate_to = navigate_to
 
+    @ui.refreshable_method
     def render(self) -> None:
         """Render the run analysis button and summary."""
         analyzer = self.session.selected_analyzer
         column_mapping = self.session.column_mapping
         params = self.session.analysis_params
+
+        if not analyzer:
+            ui.label("Please select an analyzer first").classes("text-grey")
+            return
+
+        if not column_mapping:
+            ui.label("Please map columns first").classes("text-grey")
+            return
 
         with (
             ui.column()

--- a/gui/components/stepper_steps/run_step.py
+++ b/gui/components/stepper_steps/run_step.py
@@ -1,0 +1,194 @@
+import asyncio
+from traceback import format_exc
+
+from nicegui import ui
+
+from gui.base import GuiSession, gui_routes
+
+UI_RENDER_DELAY = 0.1
+
+
+class RunAnalysisStep:
+    """Step 4: Execute the analysis with progress tracking."""
+
+    def __init__(
+        self,
+        session: GuiSession,
+        notify_success,
+        notify_warning,
+        notify_error,
+        navigate_to,
+    ):
+        self.session = session
+        self.notify_success = notify_success
+        self.notify_warning = notify_warning
+        self.notify_error = notify_error
+        self.navigate_to = navigate_to
+
+    def render(self) -> None:
+        """Render the run analysis button and summary."""
+        analyzer = self.session.selected_analyzer
+        column_mapping = self.session.column_mapping
+        params = self.session.analysis_params
+
+        with (
+            ui.column()
+            .classes("w-full items-center gap-6")
+            .style("max-width: 960px; margin: 0 auto;")
+        ):
+            ui.label("Configuration Summary").classes("text-lg font-bold mb-4")
+
+            with ui.card().classes("w-full p-4 no-shadow border border-gray-200"):
+                with ui.column().classes("gap-2"):
+                    ui.label(
+                        f"Analyzer: {analyzer.name if analyzer else 'Not selected'}"
+                    ).classes("text-sm")
+                    ui.label(
+                        f"Columns: {len(column_mapping) if column_mapping else 0} mapped"
+                    ).classes("text-sm")
+                    ui.label(
+                        f"Parameters: {len(params) if params else 0} configured"
+                    ).classes("text-sm")
+
+            ui.button(
+                "Run Analysis",
+                icon="play_arrow",
+                color="primary",
+                on_click=self._start_analysis,
+            ).classes("text-base")
+
+    def is_valid(self) -> bool:
+        """Check if all prerequisites are configured."""
+        return (
+            self.session.selected_analyzer is not None
+            and self.session.column_mapping is not None
+            and self.session.analysis_params is not None
+        )
+
+    async def _start_analysis(self) -> None:
+        """Opens dialog and runs the analysis."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+
+        if not analyzer or not project:
+            self.notify_error("Missing analyzer or project")
+            return
+
+        try:
+            analysis = project.create_analysis(
+                analyzer.id,
+                self.session.column_mapping,
+                self.session.analysis_params,
+            )
+        except Exception as e:
+            self.notify_error(f"Failed to create analysis: {str(e)}")
+            print(f"Analysis creation error:\n{format_exc()}")
+            return
+
+        secondary_analyzers = (
+            self.session.app.context.suite.find_toposorted_secondary_analyzers(analyzer)
+        )
+        total_steps = 1 + len(secondary_analyzers)
+
+        cancel_requested = False
+
+        def request_cancel():
+            nonlocal cancel_requested
+            cancel_requested = True
+            cancel_btn.text = "Canceling..."
+            cancel_btn.disable()
+
+        with (
+            ui.dialog().props("persistent") as dialog,
+            ui.card()
+            .classes("items-center justify-center gap-6")
+            .style("width: 600px; max-width: 90vw; padding: 2rem;"),
+        ):
+            ui.label("Running Analysis").classes("text-xl font-bold")
+
+            progress_bar = ui.linear_progress(value=0).classes("w-full")
+
+            step_checkboxes = []
+            with ui.column().classes("w-full gap-1"):
+                primary_checkbox = ui.checkbox(analyzer.name, value=False).props(
+                    "disable"
+                )
+                step_checkboxes.append(primary_checkbox)
+
+                for secondary in secondary_analyzers:
+                    checkbox = ui.checkbox(secondary.name, value=False).props("disable")
+                    step_checkboxes.append(checkbox)
+
+            log_container = ui.column().classes("w-full gap-1")
+
+            with ui.row().classes("gap-4 mt-4"):
+                cancel_btn = ui.button(
+                    "Cancel Analysis",
+                    icon="stop",
+                    color="secondary",
+                    on_click=request_cancel,
+                ).props("outline")
+
+                success_btn = ui.button(
+                    "Continue",
+                    icon="arrow_forward",
+                    color="primary",
+                    on_click=lambda: (
+                        dialog.close(),
+                        self.navigate_to(gui_routes.post_analysis),
+                    ),
+                )
+                success_btn.set_visibility(False)
+
+        async def run_analysis_task():
+            nonlocal cancel_requested
+            current_step = 0
+
+            try:
+                for event in analysis.run():
+                    if cancel_requested:
+                        with log_container:
+                            ui.label("Analysis canceled by user").classes(
+                                "text-warning text-sm"
+                            )
+                        raise KeyboardInterrupt("User canceled analysis")
+
+                    if event.event == "start":
+                        current_step += 1
+                        progress_bar.value = current_step / total_steps
+
+                    elif event.event == "finish":
+                        if current_step > 0 and current_step <= len(step_checkboxes):
+                            step_checkboxes[current_step - 1].value = True
+
+                    await asyncio.sleep(0.01)
+
+                self.session.current_analysis = analysis.model
+
+                success_btn.set_visibility(True)
+                cancel_btn.disable()
+
+                self.notify_success("Analysis completed!")
+
+            except KeyboardInterrupt:
+                self.notify_warning("Analysis was canceled")
+                cancel_btn.disable()
+
+            except Exception as e:
+                self.notify_error(f"Analysis error: {str(e)}")
+
+                with log_container:
+                    ui.label(f"Error: {str(e)}").classes(
+                        "text-negative font-bold text-sm"
+                    )
+
+                print(f"Analysis error:\n{format_exc()}")
+                cancel_btn.disable()
+
+            finally:
+                if analysis.is_draft:
+                    analysis.delete()
+
+        dialog.open()
+        await asyncio.sleep(UI_RENDER_DELAY)
+        await run_analysis_task()

--- a/gui/main_workflow.py
+++ b/gui/main_workflow.py
@@ -10,15 +10,11 @@ from gui.context import GUIContext
 from gui.dashboards import BaseDashboardPage, NgramsDashboardPage
 from gui.pages import (
     AnalysisConfigPage,
-    ConfigureAnalaysisParams,
-    ConfigureAnalysisDatasetPage,
     ImportDatasetPage,
     NewProjectPage,
     PostAnalysisPage,
     PreviewDatasetPage,
-    RunAnalysisPage,
     SelectAnalyzerForkPage,
-    SelectNewAnalyzerPage,
     SelectPreviousAnalyzerPage,
     SelectProjectPage,
     StartPage,
@@ -109,34 +105,10 @@ def gui_main(app: App):
         page = AnalysisConfigPage(session=gui_session)
         page.render()
 
-    @ui.page(gui_routes.select_analyzer)
-    def select_analyzer():
-        """New analyzer selection page using GuiPage abstraction."""
-        page = SelectNewAnalyzerPage(session=gui_session)
-        page.render()
-
     @ui.page(gui_routes.select_previous_analyzer)
     def select_previous_analyzer():
         """Previous analyzer selection page using GuiPage abstraction."""
         page = SelectPreviousAnalyzerPage(session=gui_session)
-        page.render()
-
-    @ui.page(gui_routes.configure_analysis_dataset)
-    def configure_analysis_dataset():
-        """Renders page where user selects dataset columns and previews."""
-        page = ConfigureAnalysisDatasetPage(session=gui_session)
-        page.render()
-
-    @ui.page(gui_routes.configure_analysis_parameters)
-    def configure_analysis_parameters():
-        """Render page to allow user to configure analysis parameters."""
-        page = ConfigureAnalaysisParams(session=gui_session)
-        page.render()
-
-    @ui.page(gui_routes.run_analysis)
-    def run_analysis():
-        """Render page that runs the analysis with selected parameters."""
-        page = RunAnalysisPage(session=gui_session)
         page.render()
 
     @ui.page(gui_routes.post_analysis)

--- a/gui/main_workflow.py
+++ b/gui/main_workflow.py
@@ -9,6 +9,7 @@ from gui.base import GuiSession, gui_routes
 from gui.context import GUIContext
 from gui.dashboards import BaseDashboardPage, NgramsDashboardPage
 from gui.pages import (
+    AnalysisConfigPage,
     ConfigureAnalaysisParams,
     ConfigureAnalysisDatasetPage,
     ImportDatasetPage,
@@ -100,6 +101,12 @@ def gui_main(app: App):
     @ui.page(gui_routes.select_analyzer_fork)
     def select_analyzer_fork():
         page = SelectAnalyzerForkPage(session=gui_session)
+        page.render()
+
+    @ui.page(gui_routes.configure_analysis)
+    def configure_analysis():
+        """Combined analysis configuration page with stepper."""
+        page = AnalysisConfigPage(session=gui_session)
         page.render()
 
     @ui.page(gui_routes.select_analyzer)

--- a/gui/pages/__init__.py
+++ b/gui/pages/__init__.py
@@ -1,9 +1,5 @@
 from .analysis_config import AnalysisConfigPage
-from .analysis_dataset import ConfigureAnalysisDatasetPage
-from .analysis_params import ConfigureAnalaysisParams
 from .analysis_post import PostAnalysisPage
-from .analysis_run import RunAnalysisPage
-from .analyzer_new import SelectNewAnalyzerPage
 from .analyzer_previous import SelectPreviousAnalyzerPage
 from .analyzer_select import SelectAnalyzerForkPage
 from .dataset_preview import PreviewDatasetPage
@@ -18,12 +14,8 @@ __all__ = [
     "NewProjectPage",
     "ImportDatasetPage",
     "SelectAnalyzerForkPage",
-    "SelectNewAnalyzerPage",
     "SelectPreviousAnalyzerPage",
     "AnalysisConfigPage",
-    "ConfigureAnalysisDatasetPage",
-    "ConfigureAnalaysisParams",
-    "RunAnalysisPage",
     "PostAnalysisPage",
     "PreviewDatasetPage",
 ]

--- a/gui/pages/__init__.py
+++ b/gui/pages/__init__.py
@@ -1,3 +1,4 @@
+from .analysis_config import AnalysisConfigPage
 from .analysis_dataset import ConfigureAnalysisDatasetPage
 from .analysis_params import ConfigureAnalaysisParams
 from .analysis_post import PostAnalysisPage
@@ -19,6 +20,7 @@ __all__ = [
     "SelectAnalyzerForkPage",
     "SelectNewAnalyzerPage",
     "SelectPreviousAnalyzerPage",
+    "AnalysisConfigPage",
     "ConfigureAnalysisDatasetPage",
     "ConfigureAnalaysisParams",
     "RunAnalysisPage",

--- a/gui/pages/analysis_config.py
+++ b/gui/pages/analysis_config.py
@@ -1,0 +1,144 @@
+from nicegui import ui
+
+from gui.base import GuiPage, GuiSession, gui_routes
+from gui.components.stepper_steps import (
+    AnalyzerSelectionStep,
+    ColumnMappingStep,
+    ParamsConfigStep,
+    RunAnalysisStep,
+)
+
+
+class AnalysisConfigPage(GuiPage):
+    """Combined analysis configuration using a stepper."""
+
+    def __init__(self, session: GuiSession):
+        config_title = "Configure Analysis"
+        super().__init__(
+            session=session,
+            route=gui_routes.configure_analysis,
+            title=(
+                f"{session.current_project.display_name}: {config_title}"
+                if session.current_project is not None
+                else config_title
+            ),
+            show_back_button=True,
+            back_route=gui_routes.select_analyzer_fork,
+            show_footer=True,
+        )
+        self.stepper = None
+        self.steps: dict = {}
+
+    def render_content(self) -> None:
+        """Render the stepper with all configuration steps."""
+        if not self.session.current_project:
+            self.notify_warning("No project selected. Redirecting...")
+            self.navigate_to(gui_routes.select_project)
+            return
+
+        with (
+            ui.column()
+            .classes("items-center justify-start gap-6")
+            .style("width: 100%; max-width: 1200px; margin: 0 auto; padding: 2rem;")
+        ):
+            with ui.stepper().props("vertical animated").classes("w-full") as stepper:
+                self.stepper = stepper
+
+                self._render_analyzer_step()
+                self._render_column_mapping_step()
+                self._render_params_step()
+                self._render_run_step()
+
+    def _render_analyzer_step(self) -> None:
+        """Render Step 1: Analyzer Selection."""
+        with ui.step("Select Analyzer", icon="science"):
+            self.steps["analyzer"] = AnalyzerSelectionStep(self.session)
+            self.steps["analyzer"].render()
+
+            with ui.stepper_navigation():
+                ui.button(
+                    "Next",
+                    icon="arrow_forward",
+                    color="primary",
+                    on_click=self._on_next_analyzer,
+                )
+
+    def _render_column_mapping_step(self) -> None:
+        """Render Step 2: Column Mapping."""
+        with ui.step("Map Columns", icon="table"):
+            self.steps["columns"] = ColumnMappingStep(self.session)
+            self.steps["columns"].render()
+
+            with ui.stepper_navigation():
+                ui.button(
+                    "Next",
+                    icon="arrow_forward",
+                    color="primary",
+                    on_click=self._on_next_columns,
+                )
+                ui.button("Back", on_click=self.stepper.previous).props("flat")
+
+    def _render_params_step(self) -> None:
+        """Render Step 3: Parameter Configuration."""
+        with ui.step("Configure Parameters", icon="tune"):
+            self.steps["params"] = ParamsConfigStep(self.session)
+            self.steps["params"].render()
+
+            with ui.stepper_navigation():
+                ui.button(
+                    "Next",
+                    icon="arrow_forward",
+                    color="primary",
+                    on_click=self._on_next_params,
+                )
+                ui.button("Back", on_click=self.stepper.previous).props("flat")
+
+    def _render_run_step(self) -> None:
+        """Render Step 4: Run Analysis."""
+        with ui.step("Run Analysis", icon="play_arrow"):
+            self.steps["run"] = RunAnalysisStep(
+                session=self.session,
+                notify_success=self.notify_success,
+                notify_warning=self.notify_warning,
+                notify_error=self.notify_error,
+                navigate_to=self.navigate_to,
+            )
+            self.steps["run"].render()
+
+            with ui.stepper_navigation():
+                ui.button("Back", on_click=self.stepper.previous).props("flat")
+
+    def _on_next_analyzer(self) -> None:
+        """Handle Next from analyzer selection step."""
+        step = self.steps.get("analyzer")
+        if not step:
+            return
+
+        if not step.is_valid():
+            self.notify_warning("Please select an analyzer")
+            return
+
+        if step.save_state():
+            self.stepper.next()
+
+    def _on_next_columns(self) -> None:
+        """Handle Next from column mapping step."""
+        step = self.steps.get("columns")
+        if not step:
+            return
+
+        if not step.is_valid():
+            self.notify_warning("Please map all required columns")
+            return
+
+        if step.save_state():
+            self.stepper.next()
+
+    def _on_next_params(self) -> None:
+        """Handle Next from parameters step."""
+        step = self.steps.get("params")
+        if not step:
+            return
+
+        if step.save_state():
+            self.stepper.next()

--- a/gui/pages/analysis_config.py
+++ b/gui/pages/analysis_config.py
@@ -76,8 +76,9 @@ class AnalysisConfigPage(GuiPage):
     def _render_analyzer_step(self) -> None:
         """Render Step 1: Analyzer Selection."""
         with ui.step("Select Analyzer", icon="science"):
-            self.steps["analyzer"] = AnalyzerSelectionStep(self.session)
-            self.steps["analyzer"].render()
+            with ui.element().classes("pt-12"):
+                self.steps["analyzer"] = AnalyzerSelectionStep(self.session)
+                self.steps["analyzer"].render()
 
             with ui.stepper_navigation():
                 ui.button(
@@ -89,9 +90,10 @@ class AnalysisConfigPage(GuiPage):
 
     def _render_column_mapping_step(self) -> None:
         """Render Step 2: Column Mapping."""
-        with ui.step("Map Columns", icon="table"):
-            self.steps["columns"] = ColumnMappingStep(self.session)
-            self.steps["columns"].render()
+        with ui.step("Map Columns", icon="pivot_table_chart"):
+            with ui.element().classes("pt-6"):
+                self.steps["columns"] = ColumnMappingStep(self.session)
+                self.steps["columns"].render()
 
             with ui.stepper_navigation():
                 ui.button(
@@ -105,8 +107,9 @@ class AnalysisConfigPage(GuiPage):
     def _render_params_step(self) -> None:
         """Render Step 3: Parameter Configuration."""
         with ui.step("Configure Parameters", icon="tune"):
-            self.steps["params"] = ParamsConfigStep(self.session)
-            self.steps["params"].render()
+            with ui.element().classes("pt-6"):
+                self.steps["params"] = ParamsConfigStep(self.session)
+                self.steps["params"].render()
 
             with ui.stepper_navigation():
                 ui.button(
@@ -120,14 +123,15 @@ class AnalysisConfigPage(GuiPage):
     def _render_run_step(self) -> None:
         """Render Step 4: Run Analysis."""
         with ui.step("Run Analysis", icon="play_arrow"):
-            self.steps["run"] = RunAnalysisStep(
-                session=self.session,
-                notify_success=self.notify_success,
-                notify_warning=self.notify_warning,
-                notify_error=self.notify_error,
-                navigate_to=self.navigate_to,
-            )
-            self.steps["run"].render()
+            with ui.element().classes("pt-6"):
+                self.steps["run"] = RunAnalysisStep(
+                    session=self.session,
+                    notify_success=self.notify_success,
+                    notify_warning=self.notify_warning,
+                    notify_error=self.notify_error,
+                    navigate_to=self.navigate_to,
+                )
+                self.steps["run"].render()
 
             with ui.stepper_navigation():
                 ui.button("Back", on_click=self.stepper.previous).props("flat")

--- a/gui/pages/analysis_config.py
+++ b/gui/pages/analysis_config.py
@@ -76,7 +76,7 @@ class AnalysisConfigPage(GuiPage):
     def _render_analyzer_step(self) -> None:
         """Render Step 1: Analyzer Selection."""
         with ui.step("Select Analyzer", icon="science"):
-            with ui.element().classes("pt-12"):
+            with ui.element().classes("pt-12 w-full items-center"):
                 self.steps["analyzer"] = AnalyzerSelectionStep(self.session)
                 self.steps["analyzer"].render()
 
@@ -91,7 +91,7 @@ class AnalysisConfigPage(GuiPage):
     def _render_column_mapping_step(self) -> None:
         """Render Step 2: Column Mapping."""
         with ui.step("Map Columns", icon="pivot_table_chart"):
-            with ui.element().classes("pt-6"):
+            with ui.element().classes("pt-6 w-full items-center"):
                 self.steps["columns"] = ColumnMappingStep(self.session)
                 self.steps["columns"].render()
 
@@ -107,7 +107,7 @@ class AnalysisConfigPage(GuiPage):
     def _render_params_step(self) -> None:
         """Render Step 3: Parameter Configuration."""
         with ui.step("Configure Parameters", icon="tune"):
-            with ui.element().classes("pt-6"):
+            with ui.element().classes("pt-6 w-full items-center"):
                 self.steps["params"] = ParamsConfigStep(self.session)
                 self.steps["params"].render()
 
@@ -123,7 +123,7 @@ class AnalysisConfigPage(GuiPage):
     def _render_run_step(self) -> None:
         """Render Step 4: Run Analysis."""
         with ui.step("Run Analysis", icon="play_arrow"):
-            with ui.element().classes("pt-6"):
+            with ui.element().classes("pt-6 w-full items-center"):
                 self.steps["run"] = RunAnalysisStep(
                     session=self.session,
                     notify_success=self.notify_success,

--- a/gui/pages/analysis_config.py
+++ b/gui/pages/analysis_config.py
@@ -10,6 +10,13 @@ from gui.components.stepper_steps import (
     RunAnalysisStep,
 )
 
+STEP_NAMES = {
+    "Select Analyzer": "analyzer",
+    "Map Columns": "columns",
+    "Configure Parameters": "params",
+    "Run Analysis": "run",
+}
+
 
 class AnalysisConfigPage(GuiPage):
     """Combined analysis configuration using a stepper."""
@@ -44,13 +51,27 @@ class AnalysisConfigPage(GuiPage):
             .classes("items-center justify-start gap-6")
             .style("width: 100%; max-width: 1200px; margin: 0 auto; padding: 2rem;")
         ):
-            with ui.stepper().props("vertical animated").classes("w-full") as stepper:
+            with (
+                ui.stepper()
+                .props("horizontal animated")
+                .classes("w-full")
+                .on_value_change(self._on_step_change) as stepper
+            ):
                 self.stepper = stepper
 
                 self._render_analyzer_step()
                 self._render_column_mapping_step()
                 self._render_params_step()
                 self._render_run_step()
+
+    def _on_step_change(self, event) -> None:
+        """Refresh the step content when navigating to it."""
+        step_name = (
+            event.value.name if hasattr(event.value, "name") else str(event.value)
+        )
+        step_key = STEP_NAMES.get(step_name)
+        if step_key and step_key in self.steps:
+            self.steps[step_key].render.refresh()
 
     def _render_analyzer_step(self) -> None:
         """Render Step 1: Analyzer Selection."""

--- a/gui/pages/analysis_config.py
+++ b/gui/pages/analysis_config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from nicegui import ui
 
 from gui.base import GuiPage, GuiSession, gui_routes
@@ -11,6 +13,9 @@ from gui.components.stepper_steps import (
 
 class AnalysisConfigPage(GuiPage):
     """Combined analysis configuration using a stepper."""
+
+    stepper: Any = None
+    steps: dict = {}
 
     def __init__(self, session: GuiSession):
         config_title = "Configure Analysis"
@@ -26,8 +31,6 @@ class AnalysisConfigPage(GuiPage):
             back_route=gui_routes.select_analyzer_fork,
             show_footer=True,
         )
-        self.stepper = None
-        self.steps: dict = {}
 
     def render_content(self) -> None:
         """Render the stepper with all configuration steps."""

--- a/gui/pages/analysis_post.py
+++ b/gui/pages/analysis_post.py
@@ -10,7 +10,7 @@ class PostAnalysisPage(GuiPage):
             route=gui_routes.post_analysis,
             title=f"{session.current_project.display_name}: Configure Parameters",
             show_back_button=True,
-            back_route=gui_routes.configure_analysis_dataset,
+            back_route=gui_routes.configure_analysis,
             show_footer=True,
         )
 

--- a/gui/pages/analyzer_select.py
+++ b/gui/pages/analyzer_select.py
@@ -24,7 +24,9 @@ class SelectAnalyzerForkPage(GuiPage):
             prompt="What do you want to do next?",
             left_button_label="Start a New Test",
             left_button_icon="computer",
-            left_button_on_click=lambda: self.navigate_to(gui_routes.select_analyzer),
+            left_button_on_click=lambda: self.navigate_to(
+                gui_routes.configure_analysis
+            ),
             right_button_label="Review a Previous Test",
             right_button_on_click=lambda: self.navigate_to(
                 gui_routes.select_previous_analyzer

--- a/gui/pages/dataset_preview.py
+++ b/gui/pages/dataset_preview.py
@@ -132,7 +132,7 @@ class PreviewDatasetPage(GuiPage):
                     self.session.current_project = project
 
                     # Navigate to analyzer selection
-                    self.navigate_to(gui_routes.select_analyzer)
+                    self.navigate_to(gui_routes.configure_analysis)
 
                 except Exception as e:
                     self.notify_error(f"Error creating project: {str(e)}")


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Right now the selection of analyzer, the configuration of analysis, and the configuration of the data set was all separate pages, which was not super user friendly to navigate.

Issue Number: #243 

## What is the new behavior?


https://github.com/user-attachments/assets/af368837-cb83-4bf9-adac-796931862e86



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
