### PR TITLE
fix: remove unused commit_msg output in .build_preview_gui and rename workflow

### DIFF
--- a/.github/workflows/build_preview_gui.yml
+++ b/.github/workflows/build_preview_gui.yml
@@ -1,4 +1,4 @@
-name: Build Preview Release
+name: GUI-Prototype Preview Release
 
 on:
   workflow_dispatch:
@@ -71,7 +71,6 @@ jobs:
         id: commit_info
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "commit_msg=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
 
       - name: Create VERSION file
         run: |


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Workflow crashed because I accidentally wrote a syntactically wrong commit message. It turns out the variable is unused anyway.

Issue Number: #243 

## What is the new behavior?

The unused variable is removed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
