### PR TITLE
ux: Move dashboard loading to a separate thread, add loading spinner, include Post content tooltip

### DIFF
--- a/analyzers/ngrams/ngrams_web/plots.py
+++ b/analyzers/ngrams/ngrams_web/plots.py
@@ -9,6 +9,7 @@ Dash, or NiceGUI and can therefore be imported from any GUI layer.
 import numpy as np
 import plotly.express as px
 import polars as pl
+from pydantic import BaseModel
 
 from ..ngrams_base.interface import COL_NGRAM_ID, COL_NGRAM_LENGTH
 from ..ngrams_stats.interface import (
@@ -29,6 +30,65 @@ TAB_10_PALETTE = [
     "#bcbd22",
     "#17becf",
 ]
+
+
+class SamplingMetadata(BaseModel):
+    """Metadata about data sampling applied before visualization."""
+
+    total_count: int
+    sampled_count: int
+    is_sampled: bool
+    strategy: str
+
+    @property
+    def sampling_message(self) -> str:
+        """Human-readable summary shown in the dashboard info label."""
+        if not self.is_sampled:
+            return f"Showing all {self.total_count:,} n-grams."
+        return (
+            f"Showing top {self.sampled_count:,} of {self.total_count:,} n-grams "
+            f"(by frequency). Click 'Show all' to load the complete dataset."
+        )
+
+
+def sample_ngram_data(
+    df: pl.DataFrame,
+    max_points: int = 50000,
+    sort_column: str = COL_NGRAM_TOTAL_REPS,
+) -> tuple[pl.DataFrame, SamplingMetadata]:
+    """
+    Sample n-gram data for visualization.
+
+    For datasets larger than max_points, returns the top N rows sorted by
+    frequency (total_reps). This preserves the most interesting data points
+    while keeping rendering performant.
+
+    Args:
+        df: Input DataFrame with n-gram statistics.
+        max_points: Maximum number of points to return (default 50,000).
+        sort_column: Column to sort by for sampling (default: total_reps).
+
+    Returns:
+        Tuple of (sampled_dataframe, SamplingMetadata).
+    """
+    total_count = len(df)
+
+    if total_count <= max_points:
+        return df, SamplingMetadata(
+            total_count=total_count,
+            sampled_count=total_count,
+            is_sampled=False,
+            strategy="none",
+        )
+
+    sampled = df.sort(sort_column, descending=True).head(max_points)
+
+    return sampled, SamplingMetadata(
+        total_count=total_count,
+        sampled_count=max_points,
+        is_sampled=True,
+        strategy="top_by_frequency",
+    )
 
 
 def plot_scatter(data: pl.DataFrame):
@@ -95,7 +155,10 @@ def plot_scatter(data: pl.DataFrame):
     return fig
 
 
-def plot_scatter_echart(data: pl.DataFrame) -> dict:
+def plot_scatter_echart(
+    data: pl.DataFrame,
+    enable_large_mode: bool = True,
+) -> dict:
     """
     Build a log-log scatter plot of n-gram frequency vs. unique poster count.
 
@@ -107,6 +170,8 @@ def plot_scatter_echart(data: pl.DataFrame) -> dict:
     Args:
         data: The ``ngram_stats`` Polars DataFrame (must contain the standard
               n-gram statistics columns).
+        enable_large_mode: Inject ECharts large-dataset optimizations.
+            Should be True whenever data has more than ~2,000 points.
 
     Returns:
         A plain dict representing the ECharts option object, ready to be
@@ -144,32 +209,42 @@ def plot_scatter_echart(data: pl.DataFrame) -> dict:
             }
             for row in subset.iter_rows(named=True)
         ]
-        series.append(
-            {
-                "name": f"{n}-gram",
-                "type": "scatter",
-                "color": TAB_10_PALETTE[i],
-                "symbolSize": 11,
+        series_config = {
+            "name": f"{n}-gram",
+            "type": "scatter",
+            "color": TAB_10_PALETTE[i],
+            "symbolSize": 11,
+            "itemStyle": {
+                "color": TAB_10_PALETTE[i % len(TAB_10_PALETTE)],
+                "opacity": 0.7,
+                "borderColor": "white",
+                "borderWidth": 0.5,
+            },
+            "emphasis": {
                 "itemStyle": {
-                    "color": TAB_10_PALETTE[i % len(TAB_10_PALETTE)],
-                    "opacity": 0.7,
+                    "color": "#d62728",  # Highlight red color
+                    "opacity": 1.0,
                     "borderColor": "white",
-                    "borderWidth": 0.5,
+                    "borderWidth": 2,
+                    "shadowBlur": 10,
+                    "shadowColor": "rgba(0, 0, 0, 0.3)",
                 },
-                "emphasis": {
-                    "itemStyle": {
-                        "color": "#d62728",  # Highlight red color
-                        "opacity": 1.0,
-                        "borderColor": "white",
-                        "borderWidth": 2,
-                        "shadowBlur": 10,
-                        "shadowColor": "rgba(0, 0, 0, 0.3)",
-                    },
-                    "scale": 1.5,  # Make point 50% larger when emphasized
-                },
-                "data": series_data,
-            }
-        )
+                "scale": 1.5,  # Make point 50% larger when emphasized
+            },
+            "data": series_data,
+        }
+
+        if enable_large_mode:
+            series_config.update(
+                {
+                    "large": True,
+                    "largeThreshold": 2000,
+                    "progressive": 2000,
+                    "progressiveThreshold": 10000,
+                }
+            )
+
+        series.append(series_config)
 
     option = {
         "title": {"text": "Repeated phrases and accounts"},
@@ -222,5 +297,14 @@ def plot_scatter_echart(data: pl.DataFrame) -> dict:
         },
         "series": series,
     }
+
+    if enable_large_mode:
+        option.update(
+            {
+                "animation": False,
+                "animationThreshold": 5000,
+                "hoverLayerThreshold": 10000,
+            }
+        )
 
     return option

--- a/analyzers/ngrams/ngrams_web/plots.py
+++ b/analyzers/ngrams/ngrams_web/plots.py
@@ -225,7 +225,7 @@ def plot_scatter_echart(
                     "color": "#d62728",  # Highlight red color
                     "opacity": 1.0,
                     "borderColor": "white",
-                    "borderWidth": 2,
+                    "borderWidth": 1,
                     "shadowBlur": 10,
                     "shadowColor": "rgba(0, 0, 0, 0.3)",
                 },

--- a/gui/dashboards/base_dashboard.py
+++ b/gui/dashboards/base_dashboard.py
@@ -12,6 +12,8 @@ and implement render_content().
 
 import abc
 
+from nicegui import ui
+
 from gui.base import GuiPage, GuiSession, gui_routes
 
 
@@ -49,6 +51,49 @@ class BaseDashboardPage(GuiPage, abc.ABC):
             back_route=gui_routes.post_analysis,
             show_footer=True,
         )
+
+    def _create_loading_container(
+        self, height: str = "500px"
+    ) -> tuple[ui.column, ui.column]:
+        """
+        Create a loading spinner container and a (hidden) content container.
+
+        Subclasses call this inside render_content() and later call
+        _show_content() / _show_error() to switch states.
+
+        Returns:
+            (loading_container, content_container)
+        """
+        loading_container = (
+            ui.column()
+            .classes("w-full items-center justify-center")
+            .style(f"height: {height};")
+        )
+        with loading_container:
+            ui.spinner("pie", size="xl")
+            ui.label("Loading dashboard...").classes("text-grey-6 q-mt-md")
+
+        content_container = (
+            ui.column().classes("w-full").style(f"height: {height}; display: none;")
+        )
+
+        return loading_container, content_container
+
+    def _show_content(self, loading_container: ui.column, content_container: ui.column):
+        """Switch from loading state to content display."""
+        loading_container.style("display: none;")
+        content_container.style("display: block;")
+
+    def _show_error(
+        self,
+        loading_container: ui.column,
+        message: str,
+    ) -> None:
+        """Replace loading spinner with an error message in-place."""
+        loading_container.clear()
+        with loading_container:
+            ui.icon("error_outline", size="3rem").classes("text-negative")
+            ui.label(message).classes("text-negative q-mt-md")
 
     @abc.abstractmethod
     def render_content(self) -> None:

--- a/gui/dashboards/ngrams.py
+++ b/gui/dashboards/ngrams.py
@@ -20,7 +20,11 @@ from analyzers.ngrams.ngrams_stats.interface import (
     OUTPUT_NGRAM_STATS,
 )
 from analyzers.ngrams.ngrams_stats.interface import interface as ngram_stats_interface
-from analyzers.ngrams.ngrams_web.plots import plot_scatter_echart
+from analyzers.ngrams.ngrams_web.plots import (
+    SamplingMetadata,
+    plot_scatter_echart,
+    sample_ngram_data,
+)
 from gui.base import GuiSession
 
 from .base_dashboard import BaseDashboardPage
@@ -54,11 +58,19 @@ class NgramsDashboardPage(BaseDashboardPage):
         # DataFrames
         self._df_stats: pl.DataFrame | None = None
         self._df_full: pl.DataFrame | None = None
+        self._df_stats_sampled: pl.DataFrame | None = None
+        self._sampling_metadata: SamplingMetadata | None = None
         # UI component references (set during render)
         self._chart: ui.echart | None = None
         self._grid: ui.aggrid | None = None
         self._info_label: ui.label | None = None
         self._ngram_select: ui.input | None = None
+        self._chart_loading: ui.column | None = None
+        self._chart_content: ui.column | None = None
+        self._grid_loading: ui.column | None = None
+        self._grid_content: ui.column | None = None
+        self._sampling_label: ui.label | None = None
+        self._show_all_btn: ui.button | None = None
 
     def _get_parquet_path(self, output_id: str) -> str | None:
         """
@@ -421,7 +433,7 @@ class NgramsDashboardPage(BaseDashboardPage):
         self._chart.update()
 
     def render_content(self) -> None:
-        """Render the scatter plot and data grid in full-width cards."""
+        """Render the scatter plot and data grid with loading states."""
         with ui.row().classes("w-full justify-center"):
             with ui.column().classes("w-3/4 q-pa-md gap-4"):
                 # Scatter plot card
@@ -438,103 +450,57 @@ class NgramsDashboardPage(BaseDashboardPage):
                         .on("clear", self._handle_clear)
                     )
 
-                    # Create chart with empty options and click handler
-                    self._chart = (
-                        ui.echart({}, on_point_click=self._handle_point_click)
-                        .classes("w-full")
-                        .style("height: 500px")
+                    # Loading / chart containers
+                    self._chart_loading, self._chart_content = (
+                        self._create_loading_container("500px")
                     )
-
-                    # Create placeholder for error/empty state (hidden by default)
-                    error_container = (
-                        ui.row()
-                        .classes("w-full justify-center items-center")
-                        .style("height: 500px; display: none;")
-                    )
-                    with error_container:
-                        ui.label("No n-gram data available.").classes(
-                            "text-grey-6 text-subtitle1"
+                    with self._chart_content:
+                        self._chart = (
+                            ui.echart({}, on_point_click=self._handle_point_click)
+                            .classes("w-full")
+                            .style("height: 500px")
                         )
+
+                # Sampling info row (hidden until data loads)
+                with ui.row().classes("w-full items-center gap-4"):
+                    self._sampling_label = ui.label("").classes(
+                        "text-body2 text-grey-7"
+                    )
+                    self._show_all_btn = ui.button(
+                        "Show all data",
+                        on_click=self._handle_show_all_click,
+                        color="secondary",
+                    ).props("outline dense")
+                    self._show_all_btn.set_visibility(False)
 
                 # Data viewer card
                 with ui.card().classes("w-full"):
                     with ui.card_section():
                         ui.label("Data viewer").classes("text-h6")
-
-                    # Info label showing current state
                     self._info_label = ui.label("Loading data...").classes(
                         "text-body2 text-grey-7 q-mb-sm"
                     )
-
-                    # Data grid
-                    self._grid = (
-                        ui.aggrid(
-                            {
-                                "columnDefs": [],
-                                "rowData": [],
-                                "defaultColDef": {
-                                    "sortable": True,
-                                    "filter": True,
-                                    "resizable": True,
-                                },
-                            },
-                            theme="quartz",
-                        )
-                        .classes("w-full")
-                        .style("height: 400px")
+                    # Loading / grid containers
+                    self._grid_loading, self._grid_content = (
+                        self._create_loading_container("400px")
                     )
-
-                async def load_and_render() -> None:
-                    """Load data asynchronously and update the chart and grid."""
-                    stats_path = self._get_parquet_path(OUTPUT_NGRAM_STATS)
-                    full_path = self._get_parquet_path(OUTPUT_NGRAM_FULL)
-
-                    if stats_path is None or self._chart is None:
-                        if self._chart is not None:
-                            self._chart.set_visibility(False)
-                        error_container.style("display: flex;")
-                        self.notify_error("No analysis found in the current session.")
-                        return
-
-                    try:
-                        # Load both parquet files in background thread
-                        self._df_stats = await run.io_bound(pl.read_parquet, stats_path)
-                        if full_path:
-                            self._df_full = await run.io_bound(
-                                pl.read_parquet, full_path
+                    with self._grid_content:
+                        self._grid = (
+                            ui.aggrid(
+                                {
+                                    "columnDefs": [],
+                                    "rowData": [],
+                                    "defaultColDef": {
+                                        "sortable": True,
+                                        "filter": True,
+                                        "resizable": True,
+                                    },
+                                },
+                                theme="quartz",
                             )
-                    except Exception as exc:
-                        if self._chart is not None:
-                            self._chart.set_visibility(False)
-                        error_container.style("display: flex;")
-                        self.notify_error(f"Could not load n-gram results: {exc}")
-                        return
-
-                    if self._df_stats.is_empty():
-                        if self._chart is not None:
-                            self._chart.set_visibility(False)
-                        error_container.style("display: flex;")
-                        return
-
-                    # Populate filter select with unique n-gram values
-                    if self._ngram_select is not None:
-                        self._all_ngram_options = (
-                            self._df_stats.select(pl.col(COL_NGRAM_WORDS).unique())
-                            .sort(COL_NGRAM_WORDS)
-                            .to_series()
-                            .to_list()
+                            .classes("w-full")
+                            .style("height: 400px")
                         )
-                        # Set all n-grams as autocomplete options
-                        self._ngram_select.set_autocomplete(self._all_ngram_options)
 
-                    # Build ECharts option and update chart
-                    option = plot_scatter_echart(self._df_stats)
-                    self._chart.options.update(option)
-                    self._chart.update()
-
-                    # Initialize grid with summary view
-                    self._update_info_label()
-                    self._update_grid()
-
-                # Start async loading after page renders (allows spinner to show)
-                ui.timer(0, load_and_render, once=True)
+        # Trigger async load after page renders
+        ui.timer(0, self._load_and_render_async, once=True)

--- a/gui/dashboards/ngrams.py
+++ b/gui/dashboards/ngrams.py
@@ -410,6 +410,140 @@ class NgramsDashboardPage(BaseDashboardPage):
         self._update_grid()
         self._update_info_label()
 
+    async def _load_and_render_async(self) -> None:
+        """
+        Load parquet data and build the chart, fully off the main thread.
+
+        Call order:
+            1. run.io_bound  → read parquet files
+            2. run.cpu_bound → sample data          (plots.sample_ngram_data)
+            3. run.cpu_bound → build ECharts option (plots.plot_scatter_echart)
+            4. Main thread   → push to UI
+        """
+        stats_path = self._get_parquet_path(OUTPUT_NGRAM_STATS)
+        full_path = self._get_parquet_path(OUTPUT_NGRAM_FULL)
+
+        if stats_path is None:
+            self._show_error(
+                self._chart_loading, "No analysis found in the current session."
+            )
+            return
+
+        # --- Step 1: I/O-bound parquet reads ---
+        try:
+            self._df_stats = await run.io_bound(pl.read_parquet, stats_path)
+            if full_path:
+                self._df_full = await run.io_bound(pl.read_parquet, full_path)
+        except Exception as exc:
+            self._show_error(
+                self._chart_loading, f"Could not load n-gram results: {exc}"
+            )
+            return
+
+        if self._df_stats.is_empty():
+            self._show_error(self._chart_loading, "No n-gram data available.")
+            return
+
+        # --- Steps 2 & 3: CPU-bound sampling + chart building ---
+        try:
+            self._df_stats_sampled, self._sampling_metadata = await run.cpu_bound(
+                sample_ngram_data,
+                self._df_stats,
+                50000,
+            )
+            option = await run.cpu_bound(
+                plot_scatter_echart,
+                self._df_stats_sampled,
+                True,
+            )
+        except Exception as exc:
+            self._show_error(self._chart_loading, f"Could not build chart: {exc}")
+            return
+
+        # --- Step 4: Populate autocomplete from FULL data ---
+        if self._ngram_select is not None:
+            self._all_ngram_options = (
+                self._df_stats.select(pl.col(COL_NGRAM_WORDS).unique())
+                .sort(COL_NGRAM_WORDS)
+                .to_series()
+                .to_list()
+            )
+            self._ngram_select.set_autocomplete(self._all_ngram_options)
+
+        # --- Step 5: Push to UI (main thread) ---
+        self._chart.options.update(option)
+        self._chart.update()
+        self._show_content(self._chart_loading, self._chart_content)
+
+        self._update_sampling_info_label()
+        self._update_info_label()
+        self._update_grid()
+        self._show_content(self._grid_loading, self._grid_content)
+
+    def _update_sampling_info_label(self) -> None:
+        """Update the sampling label and show/hide the 'Show all' button."""
+        if self._sampling_label is None or self._sampling_metadata is None:
+            return
+        self._sampling_label.text = self._sampling_metadata.sampling_message
+        if self._show_all_btn is not None:
+            self._show_all_btn.set_visibility(self._sampling_metadata.is_sampled)
+
+    async def _handle_show_all_click(self) -> None:
+        """Show confirmation dialog for very large datasets, then load all data."""
+        if self._df_stats is None:
+            return
+
+        total = len(self._df_stats)
+
+        if total > 100_000:
+            with ui.dialog() as dialog, ui.card():
+                ui.label(f"Load all {total:,} data points?").classes("text-h6")
+                ui.label(
+                    "This may cause the browser to slow down or become unresponsive."
+                ).classes("text-body2 text-grey-7")
+                with ui.row().classes("gap-4 justify-end"):
+                    ui.button("Cancel", on_click=dialog.close).props("flat")
+
+                    async def _confirm():
+                        dialog.close()
+                        await self._load_full_dataset()
+
+                    ui.button("Load all", on_click=_confirm, color="primary")
+            dialog.open()
+        else:
+            await self._load_full_dataset()
+
+    async def _load_full_dataset(self) -> None:
+        """Rebuild the chart from the complete (unsampled) dataset."""
+        if self._show_all_btn is not None:
+            self._show_all_btn.set_enabled(False)
+        if self._sampling_label is not None:
+            self._sampling_label.text = "Loading full dataset..."
+
+        try:
+            option = await run.cpu_bound(
+                plot_scatter_echart,
+                self._df_stats,
+                True,
+            )
+        except Exception as exc:
+            self.notify_error(f"Could not load full dataset: {exc}")
+            if self._show_all_btn is not None:
+                self._show_all_btn.set_enabled(True)
+            return
+
+        self._df_stats_sampled = self._df_stats
+        self._sampling_metadata = SamplingMetadata(
+            total_count=len(self._df_stats),
+            sampled_count=len(self._df_stats),
+            is_sampled=False,
+            strategy="none",
+        )
+
+        self._chart.options.update(option)
+        self._chart.update()
+        self._update_sampling_info_label()
+
     def _update_chart_with_filter(self) -> None:
         """
         Re-render the chart with filtered data.

--- a/gui/dashboards/ngrams.py
+++ b/gui/dashboards/ngrams.py
@@ -51,15 +51,18 @@ class NgramsDashboardPage(BaseDashboardPage):
         self._selected_words: str | None = None
         self._selected_series_index: int | None = None
         self._selected_data_index: int | None = None
+
         # State for filter
         self._filter_text: str | None = None
         self._filter_applied: bool = False
         self._all_ngram_options: list[str] = []
+
         # DataFrames
         self._df_stats: pl.DataFrame | None = None
         self._df_full: pl.DataFrame | None = None
         self._df_stats_sampled: pl.DataFrame | None = None
         self._sampling_metadata: SamplingMetadata | None = None
+
         # UI component references (set during render)
         self._chart: ui.echart | None = None
         self._grid: ui.aggrid | None = None
@@ -264,8 +267,6 @@ class NgramsDashboardPage(BaseDashboardPage):
             series_index: Index of the series containing the point
             data_index: Index of the data point within the series
         """
-        if self._chart is None:
-            return
         self._chart.run_chart_method(
             "dispatchAction",
             {"type": "downplay", "seriesIndex": series_index, "dataIndex": data_index},
@@ -278,8 +279,6 @@ class NgramsDashboardPage(BaseDashboardPage):
         Calling dispatchAction with type 'downplay' without specifying
         seriesIndex/dataIndex will downplay all highlighted elements.
         """
-        if self._chart is None:
-            return
         self._chart.run_chart_method("dispatchAction", {"type": "downplay"})
 
     def _handle_point_click(self, e) -> None:
@@ -430,9 +429,10 @@ class NgramsDashboardPage(BaseDashboardPage):
         full_path = self._get_parquet_path(OUTPUT_NGRAM_FULL)
 
         if stats_path is None:
-            self._show_error(
-                self._chart_loading, "No analysis found in the current session."
-            )
+            if self._chart_loading is not None:
+                self._show_error(
+                    self._chart_loading, "No analysis found in the current session."
+                )
             return
 
         # --- Step 1: I/O-bound parquet reads ---
@@ -441,13 +441,15 @@ class NgramsDashboardPage(BaseDashboardPage):
             if full_path:
                 self._df_full = await run.io_bound(pl.read_parquet, full_path)
         except Exception as exc:
-            self._show_error(
-                self._chart_loading, f"Could not load n-gram results: {exc}"
-            )
+            if self._chart_loading is not None:
+                self._show_error(
+                    self._chart_loading, f"Could not load n-gram results: {exc}"
+                )
             return
 
         if self._df_stats.is_empty():
-            self._show_error(self._chart_loading, "No n-gram data available.")
+            if self._chart_loading is not None:
+                self._show_error(self._chart_loading, "No n-gram data available.")
             return
 
         # --- Steps 2 & 3: CPU-bound sampling + chart building ---
@@ -460,10 +462,11 @@ class NgramsDashboardPage(BaseDashboardPage):
             option = await run.cpu_bound(
                 plot_scatter_echart,
                 self._df_stats_sampled,
-                True,
+                False,
             )
         except Exception as exc:
-            self._show_error(self._chart_loading, f"Could not build chart: {exc}")
+            if self._chart_loading is not None:
+                self._show_error(self._chart_loading, f"Could not build chart: {exc}")
             return
 
         # --- Step 4: Populate autocomplete from FULL data ---
@@ -477,6 +480,12 @@ class NgramsDashboardPage(BaseDashboardPage):
             self._ngram_select.set_autocomplete(self._all_ngram_options)
 
         # --- Step 5: Push to UI (main thread) ---
+        if (
+            self._chart is None
+            or self._chart_content is None
+            or self._chart_loading is None
+        ):
+            return
         self._chart.options.update(option)
         self._chart.update()
         self._show_content(self._chart_loading, self._chart_content)
@@ -484,7 +493,8 @@ class NgramsDashboardPage(BaseDashboardPage):
         self._update_sampling_info_label()
         self._update_info_label()
         self._update_grid()
-        self._show_content(self._grid_loading, self._grid_content)
+        if self._grid_loading is not None and self._grid_content is not None:
+            self._show_content(self._grid_loading, self._grid_content)
 
     def _update_sampling_info_label(self) -> None:
         """Update the sampling label and show/hide the 'Show all' button."""
@@ -526,11 +536,16 @@ class NgramsDashboardPage(BaseDashboardPage):
         if self._sampling_label is not None:
             self._sampling_label.text = "Loading full dataset..."
 
+        if self._df_stats is None:
+            return
+
+        df_stats = self._df_stats
+
         try:
             option = await run.cpu_bound(
                 plot_scatter_echart,
-                self._df_stats,
-                True,
+                df_stats,
+                False,
             )
         except Exception as exc:
             self.notify_error(f"Could not load full dataset: {exc}")
@@ -538,16 +553,17 @@ class NgramsDashboardPage(BaseDashboardPage):
                 self._show_all_btn.set_enabled(True)
             return
 
-        self._df_stats_sampled = self._df_stats
+        self._df_stats_sampled = df_stats
         self._sampling_metadata = SamplingMetadata(
-            total_count=len(self._df_stats),
-            sampled_count=len(self._df_stats),
+            total_count=len(df_stats),
+            sampled_count=len(df_stats),
             is_sampled=False,
             strategy="none",
         )
 
-        self._chart.options.update(option)
-        self._chart.update()
+        if self._chart is not None:
+            self._chart.options.update(option)
+            self._chart.update()
         self._update_sampling_info_label()
 
     def _update_chart_with_filter(self) -> None:
@@ -563,7 +579,7 @@ class NgramsDashboardPage(BaseDashboardPage):
             return
 
         # Filter results are already a small subset — run synchronously
-        option = plot_scatter_echart(df_filtered, enable_large_mode=True)
+        option = plot_scatter_echart(df_filtered, enable_large_mode=False)
         self._chart.options.update(option)
         self._chart.update()
 

--- a/gui/dashboards/ngrams.py
+++ b/gui/dashboards/ngrams.py
@@ -235,10 +235,20 @@ class NgramsDashboardPage(BaseDashboardPage):
         else:
             # Convert to ag-grid format
             self._grid.options["rowData"] = df_display.to_dicts()
-            self._grid.options["columnDefs"] = [
-                {"field": col, "sortable": True, "filter": True, "resizable": True}
-                for col in df_display.columns
-            ]
+            # Build column definitions with special handling for Post content
+            column_defs = []
+            for col in df_display.columns:
+                col_def = {
+                    "field": col,
+                    "sortable": True,
+                    "filter": True,
+                    "resizable": True,
+                }
+                # Add tooltip for Post content column to show full text on hover
+                if col == "Post content":
+                    col_def[":tooltipValueGetter"] = "(params) => params.value"
+                column_defs.append(col_def)
+            self._grid.options["columnDefs"] = column_defs
         self._grid.update()
 
     def _highlight_point(self, series_index: int, data_index: int) -> None:
@@ -646,6 +656,8 @@ class NgramsDashboardPage(BaseDashboardPage):
                                         "filter": True,
                                         "resizable": True,
                                     },
+                                    "tooltipShowDelay": 200,
+                                    "tooltipSwitchShowDelay": 0,
                                 },
                                 theme="quartz",
                             )

--- a/gui/dashboards/ngrams.py
+++ b/gui/dashboards/ngrams.py
@@ -595,6 +595,15 @@ class NgramsDashboardPage(BaseDashboardPage):
 
     def render_content(self) -> None:
         """Render the scatter plot and data grid with loading states."""
+        ui.add_css(
+            """
+            .ag-tooltip {
+                white-space: normal !important;
+                max-width: 450px !important;
+                word-wrap: break-word !important;
+            }
+        """
+        )
         with ui.row().classes("w-full justify-center"):
             with ui.column().classes("w-3/4 q-pa-md gap-4"):
                 # Scatter plot card

--- a/gui/dashboards/ngrams.py
+++ b/gui/dashboards/ngrams.py
@@ -657,7 +657,7 @@ class NgramsDashboardPage(BaseDashboardPage):
                                         "resizable": True,
                                     },
                                     "tooltipShowDelay": 200,
-                                    "tooltipSwitchShowDelay": 0,
+                                    "tooltipSwitchShowDelay": 70,
                                 },
                                 theme="quartz",
                             )

--- a/gui/dashboards/ngrams.py
+++ b/gui/dashboards/ngrams.py
@@ -371,18 +371,24 @@ class NgramsDashboardPage(BaseDashboardPage):
 
     def _get_filtered_stats(self) -> pl.DataFrame:
         """
-        Get df_stats filtered by the current filter text.
+        Return a filtered view of the n-gram stats.
 
-        Returns:
-            Filtered DataFrame or full df_stats if no filter is active
+        - No active filter  → returns self._df_stats_sampled (fast default view)
+        - Active filter     → searches self._df_stats (full data) so users can
+                              find any n-gram, not just those in the sampled view.
         """
         if self._df_stats is None:
             return pl.DataFrame()
 
         if not self._filter_text:
-            return self._df_stats
+            # Default: return sampled data for performance
+            return (
+                self._df_stats_sampled
+                if self._df_stats_sampled is not None
+                else self._df_stats
+            )
 
-        # Substring/contains match (case-insensitive)
+        # Filter: always search full dataset
         return self._df_stats.filter(
             pl.col(COL_NGRAM_WORDS).str.contains(f"(?i){self._filter_text}")
         )
@@ -545,24 +551,19 @@ class NgramsDashboardPage(BaseDashboardPage):
         self._update_sampling_info_label()
 
     def _update_chart_with_filter(self) -> None:
-        """
-        Re-render the chart with filtered data.
-
-        Applies the current filter text to show only matching n-grams.
-        """
+        """Re-render the chart with the currently filtered data."""
         if self._chart is None:
             return
 
         df_filtered = self._get_filtered_stats()
 
         if df_filtered.is_empty():
-            # Show empty chart state
             self._chart.options.clear()
             self._chart.update()
             return
 
-        # Build ECharts option with filtered data
-        option = plot_scatter_echart(df_filtered)
+        # Filter results are already a small subset — run synchronously
+        option = plot_scatter_echart(df_filtered, enable_large_mode=True)
         self._chart.options.update(option)
         self._chart.update()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 pyarrow-stubs==17.13
 black==24.10.0
 isort==5.13.2
+pre-commit==4.0.1
 pytest==8.3.4
 pytest-benchmark==5.1.0
 pyinstaller==6.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ shiny==1.4.0
 shinywidgets==0.6.2
 starlette==0.47.1
 uvicorn==0.34.3
+websockets==15.0.1
 a2wsgi==1.10.10
 python-json-logger==2.0.7
 rich==14.0.0

--- a/services/tokenizer/basic/patterns.py
+++ b/services/tokenizer/basic/patterns.py
@@ -102,7 +102,11 @@ SEA_PATTERN = (
 
 # Word patterns for different script types
 
-LATIN_WORD_PATTERN = r"[a-zA-Z]+(?:\.[a-zA-Z]+)+\.?|[a-zA-Z]+(?:[-'\u2019\u0060][a-zA-Z]+)*[-'\u2019\u0060]?"  # Handle abbreviations, contractions, and possessives
+LATIN_WORD_PATTERN = (
+    r"(?:[a-zA-Z]{1,4}\.){2,}[a-zA-Z]*\.?"  # Multi-dot abbreviations: U.S.A., c.e.o.s
+    r"|[a-zA-Z]{1,4}\.(?!\.)"  # Single-dot abbreviations: Dr., Mr., Inc., vs. (not ellipsis)
+    r"|[a-zA-Z]+(?:[-'\u2019\u0060\u2013\u2014\u2011\u2012][a-zA-Z]+)*[-'\u2019\u0060]?"  # Words with contractions/hyphens/dashes
+)
 
 # Korean Hangul (space-separated, NOT character-level like Chinese/Japanese)
 KOREAN_WORD_PATTERN = r"[\uac00-\ud7af]+"

--- a/services/tokenizer/basic/test_basic_tokenizer.py
+++ b/services/tokenizer/basic/test_basic_tokenizer.py
@@ -917,6 +917,54 @@ class TestAbbreviationsAndPunctuation:
         ]  # Curly apostrophes preserved
         assert result == expected, f"Expected {expected}, got {result}"
 
+    def test_single_dot_abbreviations(self):
+        """Test single-dot abbreviations like Dr., Mr., Inc., vs., etc."""
+        tokenizer = BasicTokenizer()
+        text = "Dr. Smith met Mr. Jones"
+        result = tokenizer.tokenize(text)
+        expected = ["dr.", "smith", "met", "mr.", "jones"]
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_single_dot_abbreviations_mixed(self):
+        """Test mixed single-dot and multi-dot abbreviations."""
+        tokenizer = BasicTokenizer()
+        text = "Inc. vs. Corp. and U.S.A."
+        result = tokenizer.tokenize(text)
+        expected = ["inc.", "vs.", "corp.", "and", "u.s.a."]
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_mrs_abbreviation(self):
+        """Test Mrs. abbreviation."""
+        tokenizer = BasicTokenizer()
+        text = "Mr. Jones and Mrs. Smith"
+        result = tokenizer.tokenize(text)
+        expected = ["mr.", "jones", "and", "mrs.", "smith"]
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_unicode_en_dash_compound(self):
+        """Test en-dash (U+2013) in compound words."""
+        tokenizer = BasicTokenizer()
+        text = "well\u2013known fact"
+        result = tokenizer.tokenize(text)
+        expected = ["well\u2013known", "fact"]
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_unicode_em_dash_compound(self):
+        """Test em-dash (U+2014) in compound words."""
+        tokenizer = BasicTokenizer()
+        text = "mind\u2014blowing update"
+        result = tokenizer.tokenize(text)
+        expected = ["mind\u2014blowing", "update"]
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_unicode_non_breaking_hyphen(self):
+        """Test non-breaking hyphen (U+2011) in compound words."""
+        tokenizer = BasicTokenizer()
+        text = "self\u2011aware robot"
+        result = tokenizer.tokenize(text)
+        expected = ["self\u2011aware", "robot"]
+        assert result == expected, f"Expected {expected}, got {result}"
+
 
 @pytest.mark.unit
 class TestBotDetectionEdgeCases:

--- a/services/tokenizer/basic/tokenizer.py
+++ b/services/tokenizer/basic/tokenizer.py
@@ -237,9 +237,10 @@ class BasicTokenizer(AbstractTokenizer):
             and any(c.isalpha() for c in token)
             and "@" not in token
         ):
-            # Check if this looks like an abbreviation (single letters between periods)
-            # Pattern: letter(s).letter(s).letter(s) where segments are 1-3 chars
-            abbreviation_pattern = r"^[a-z]{1,3}(?:\.[a-z]{1,3})+\.?$"
+            # Check if this looks like an abbreviation
+            # Multi-dot: letter(s).letter(s).letter(s) where segments are 1-3 chars
+            # Single-dot: short word followed by period (Dr., Mr., Inc., vs.)
+            abbreviation_pattern = r"^[a-z]{1,4}\.$|^[a-z]{1,3}(?:\.[a-z]{1,3})+\.?$"
 
             if re.match(abbreviation_pattern, token, re.IGNORECASE):
                 return False  # This is an abbreviation, not a URL


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently the GUI would freeze when dashboards for large datasets were opened (e.g. ngram data > 10k rows). This PR addresses this by moving dashboard loading to a separate cpu thread as recommended by NiceGUI

Issue Number: #243 #302 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The GUI won't freeze when larger datasets are rendered. Specifically:

- Moves data loading, dashboard rendering to separate cpu threads (via `run.cpu_bound`, `.io_bound` methods) as is expected by NiceGUI
- Adds a spinner container that shows loading message before dashboard renders
- Add a cap to top 50k ngrams for per if dataset is large and add a "show all" button (TEMP)
- Add a tooltip preview on hover

### Spinner preview

https://github.com/user-attachments/assets/170af9bc-56bc-4e4c-8760-bdf02135825c


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
