### PR TITLE
Gui win crash

### DIFF
--- a/gui/base.py
+++ b/gui/base.py
@@ -24,7 +24,7 @@ from gui.constants.colors import (
     MANGO_ORANGE_LIGHT,
 )
 from gui.context import GUIContext
-from importing import ImporterSession
+from importing.importer import ImporterSession
 from storage import AnalysisModel
 
 

--- a/gui/pages/dataset_preview.py
+++ b/gui/pages/dataset_preview.py
@@ -6,7 +6,10 @@ from nicegui import ui
 
 from gui.base import GuiPage, GuiSession, gui_routes
 from gui.import_options import ImportOptionsDialog
-from importing import importers
+from importing.csv import CSVImporter
+from importing.excel import ExcelImporter
+
+importers = [CSVImporter(), ExcelImporter()]
 
 
 class PreviewDatasetPage(GuiPage):

--- a/importing/csv.py
+++ b/importing/csv.py
@@ -5,8 +5,6 @@ from io import BytesIO
 import polars as pl
 from pydantic import BaseModel, ConfigDict
 
-import terminal_tools.prompts as prompts
-
 from .importer import Importer, ImporterSession
 
 
@@ -186,6 +184,8 @@ class CSVImporterTerminal(CSVImporter):
         )
 
     def modify_session(self, import_session: "CsvImportSession", reset_screen):
+        import terminal_tools.prompts as prompts
+
         is_first_time = True
         while True:
             reset_screen(import_session)
@@ -233,11 +233,9 @@ class CSVImporterTerminal(CSVImporter):
 
     @staticmethod
     def _separator_option(previous_value):
-        from typing import Optional
-
         import terminal_tools.prompts as prompts
 
-        input: Optional[str] = prompts.list_input(
+        input: str | None = prompts.list_input(
             "Select the column separator",
             choices=[
                 ("comma (,)", ","),
@@ -269,7 +267,7 @@ class CSVImporterTerminal(CSVImporter):
     def _quote_char_option(previous_value):
         import terminal_tools.prompts as prompts
 
-        input: Optional[str] = prompts.list_input(
+        input: str | None = prompts.list_input(
             "Select the quote character",
             choices=[
                 ('Double quote (")', '"'),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, launching the GUI build on windows (10) crashes, with uncoupled imports from `terminal_tools` (no terminal functionality should be imported when GUI is invoked) in `csv.py` likely involved.

Issue Number: #243 

The reported error stack by a user:
<details>

<summary>Error traceback</summary>

```
File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "app\__init__.py", line 4, in <module>  
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load  
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "app\app.py", line 5, in <module>  
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load  
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "importing\__init__.py", line 1, in <module>  
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load  
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "importing\csv.py", line 8, in <module>  
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load  
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "terminal_tools\prompts.py", line 4, in <module>  
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load  
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "inquirer\__init__.py", line 1, in <module>  
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load  
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "inquirer\prompt.py", line 1, in <module>  
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load  
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked  
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked  
  File "pyimod02_importers.py", line 457, in exec_module  
  File "inquirer\themes.py", line 9, in <module>  
  File "blessed\win_terminal.py", line 115, in __init__  
  File "blessed\terminal.py", line 231, in __init__  
  File "blessed\terminal.py", line 379, in __init__streams  
AttributeError: 'NoneType' object has no attribute 'fileno'
```

</details>

## What is the new behavior?

This PR makes terminal_tools imports lazy such that the GUI code never imports them.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
