### PR TITLE
Gui win onedir

### DIFF
--- a/.github/workflows/build_preview_gui.yml
+++ b/.github/workflows/build_preview_gui.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -112,7 +112,7 @@ jobs:
           echo "artifact_name=CIBMangoTree_${ARTIFACT_NAME}-${VERSION_STRING}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.package.outputs.artifact_name }}
           path: dist/${{ steps.package.outputs.filename }}

--- a/.github/workflows/build_preview_gui.yml
+++ b/.github/workflows/build_preview_gui.yml
@@ -86,23 +86,36 @@ jobs:
           echo "Looking for: ${{ matrix.executable_name }}"
 
       - name: Package artifact
+        id: package
         shell: bash
         run: |
           VERSION="${{ github.event.inputs.version_name }}"
           SHA="${{ steps.commit_info.outputs.sha_short }}"
           ARTIFACT_NAME="${{ matrix.artifact_name }}"
 
-          if [ "${{ matrix.os }}" = "windows-2022" ]; then
-            powershell -Command "Compress-Archive -Path dist\CIBMangoTree.exe -DestinationPath dist\CIBMangoTree_${ARTIFACT_NAME}-${VERSION}-${SHA}.zip"
+          # Build version string: include SHA only if present
+          if [ -n "$SHA" ]; then
+            VERSION_STRING="${VERSION}-${SHA}"
           else
-            cd dist && zip -r "CIBMangoTree_${ARTIFACT_NAME}-${VERSION}-${SHA}.zip" CIBMangoTree.app
+            VERSION_STRING="${VERSION}"
           fi
+
+          FILENAME="CIBMangoTree_${ARTIFACT_NAME}-${VERSION_STRING}.zip"
+
+          if [ "${{ matrix.os }}" = "windows-2022" ]; then
+            powershell -Command "Compress-Archive -Path dist\CIBMangoTree\* -DestinationPath dist\${FILENAME}"
+          else
+            cd dist && zip -r "${FILENAME}" CIBMangoTree.app
+          fi
+
+          echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
+          echo "artifact_name=CIBMangoTree_${ARTIFACT_NAME}-${VERSION_STRING}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: CIBMangoTree_${{ matrix.artifact_name }}-${{ github.event.inputs.version_name }}-${{ steps.commit_info.outputs.sha_short }}
-          path: dist/CIBMangoTree_${{ matrix.artifact_name }}-${{ github.event.inputs.version_name }}-${{ steps.commit_info.outputs.sha_short }}.zip
+          name: ${{ steps.package.outputs.artifact_name }}
+          path: dist/${{ steps.package.outputs.filename }}
           retention-days: 30
       
       - name: Create Draft Release
@@ -113,7 +126,7 @@ jobs:
           prerelease: true
           tag_name: gui-preview-${{ github.event.inputs.version_name }}-${{ steps.commit_info.outputs.sha_short }}
           name: "🖥️ GUI Preview: ${{ github.event.inputs.version_name }}"
-          files: dist/CIBMangoTree_${{ matrix.artifact_name }}-${{ github.event.inputs.version_name }}-${{ steps.commit_info.outputs.sha_short }}.zip
+          files: dist/${{ steps.package.outputs.filename }}
           body: |
             # 🧪 GUI Preview Build
 

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -140,16 +140,25 @@ if sys.platform == "darwin":
         },
     )
 else:
+    # Windows/Linux: onedir mode (avoids runtime temp extraction issues with antivirus)
     exe = EXE(
         pyz,
         a.scripts,
-        a.binaries,
-        a.zipfiles,
-        a.datas,
-        name='CIBMangoTree',  # The name of the executable
+        exclude_binaries=True,  # onedir structure
+        name='CIBMangoTree',
         debug=False,
         strip=False,
         upx=True,
         console=False,  # No console window for GUI app
         icon=None,  # Add icon path when available (e.g., 'icon.ico' for Windows)
+    )
+
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=True,
+        name='CIBMangoTree',
     )


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, some windows users will have the .exe blocked by defender/antivirus. Supposedly single-file builds (i.e. a single .exe builts) are more likely to be false positives.

Issue Number: #243 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Change the Windows build to be a [onedir type](https://pyinstaller.org/en/stable/operating-mode.html#how-the-one-folder-program-works)
- Update gui_preview_build.yml to be releasing a onedir build (and update naming)
- Update workflow action v4->v6 (separate concern)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
