### PR TITLE
fix: timestamp precision mismatch in Hashtags Dashboard (GUI) gini plot clicks

### DIFF
--- a/analyzers/hashtags/hashtags_base/interface.py
+++ b/analyzers/hashtags/hashtags_base/interface.py
@@ -8,6 +8,8 @@ from analyzer_interface import (
 )
 from analyzer_interface.params import TimeBinningParam
 
+PRIMARY_OUTPUT_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
 COL_AUTHOR_ID = "Unique UserID"
 COL_TIME = "Timestamp"
 COL_POST = "Post Content"

--- a/analyzers/hashtags/hashtags_base/main.py
+++ b/analyzers/hashtags/hashtags_base/main.py
@@ -15,6 +15,7 @@ from .interface import (
     OUTPUT_COL_USERS,
     OUTPUT_GINI,
     PARAM_TIME_WINDOW,
+    PRIMARY_OUTPUT_DATETIME_FORMAT,
 )
 
 SMOOTH_WINDOW_SIZE = 3
@@ -97,7 +98,7 @@ def hashtag_analysis(data_frame: pl.DataFrame, progress, every="1h") -> pl.DataF
 
     # convert datetime back to string
     df_out = df_out.with_columns(
-        pl.col(OUTPUT_COL_TIMESPAN).dt.to_string("%Y-%m-%d %H:%M:%S")
+        pl.col(OUTPUT_COL_TIMESPAN).dt.to_string(PRIMARY_OUTPUT_DATETIME_FORMAT)
     )
 
     return df_out

--- a/gui/dashboards/hashtags/dashboard.py
+++ b/gui/dashboards/hashtags/dashboard.py
@@ -19,6 +19,7 @@ from analyzers.hashtags.hashtags_base.interface import (
     COL_TIME,
     OUTPUT_COL_HASHTAGS,
     OUTPUT_COL_TIMESPAN,
+    PRIMARY_OUTPUT_DATETIME_FORMAT,
     SECONDARY_COL_HASHTAG_PERC,
     SECONDARY_COL_USERS_ALL,
 )
@@ -27,7 +28,7 @@ from gui.session import GuiSession
 
 from ..base_dashboard import BaseDashboardPage
 from .data import (
-    USER_DATE_FORMAT,
+    DISPLAY_DATE_FORMAT,
     extract_users_for_hashtag,
     load_primary_output,
     load_transformed_raw_input,
@@ -137,7 +138,7 @@ class HashtagsDashboardPage(BaseDashboardPage):
             return None
         ts_list = self._df_primary[OUTPUT_COL_TIMESPAN].to_list()
         for i, ts in enumerate(ts_list):
-            if ts.strftime("%Y-%m-%d %H:%M") == raw_ts:
+            if ts.strftime(PRIMARY_OUTPUT_DATETIME_FORMAT) == raw_ts:
                 return i
         return None
 
@@ -185,7 +186,7 @@ class HashtagsDashboardPage(BaseDashboardPage):
             return
 
         try:
-            timewindow = datetime.strptime(raw_ts, "%Y-%m-%d %H:%M")
+            timewindow = datetime.strptime(raw_ts, PRIMARY_OUTPUT_DATETIME_FORMAT)
         except ValueError:
             return
 
@@ -326,7 +327,7 @@ class HashtagsDashboardPage(BaseDashboardPage):
             self._hashtag_info.text = "Loading hashtag data..."
         else:
             n_hashtags = len(self._df_secondary)
-            date_str = self._selected_timewindow.strftime(USER_DATE_FORMAT)
+            date_str = self._selected_timewindow.strftime(DISPLAY_DATE_FORMAT)
             self._hashtag_info.text = (
                 f"{n_hashtags} hashtags found in window starting {date_str}"
             )
@@ -488,8 +489,8 @@ class HashtagsDashboardPage(BaseDashboardPage):
 
     def _update_tweet_info(self, count: int) -> None:
         timewindow_end = self._selected_timewindow + self._get_time_step()
-        date_end = timewindow_end.strftime(USER_DATE_FORMAT)
-        date_start = self._selected_timewindow.strftime(USER_DATE_FORMAT)
+        date_end = timewindow_end.strftime(DISPLAY_DATE_FORMAT)
+        date_start = self._selected_timewindow.strftime(DISPLAY_DATE_FORMAT)
         if self._tweet_info is None:
             return
         self._tweet_info.text = f"{count} posts found for account {self._selected_user} between {date_start} and {date_end}"

--- a/gui/dashboards/hashtags/data.py
+++ b/gui/dashboards/hashtags/data.py
@@ -13,13 +13,14 @@ import polars as pl
 from analyzers.hashtags.hashtags_base.interface import (
     COL_TIME,
     OUTPUT_COL_HASHTAGS,
+    PRIMARY_OUTPUT_DATETIME_FORMAT,
     SECONDARY_COL_USERS_ALL,
 )
 from analyzers.hashtags.hashtags_web.analysis import secondary_analyzer
 from app.project_context import _get_columns_with_semantic
 from gui.session import GuiSession
 
-USER_DATE_FORMAT = "%B %d, %Y %H:%M"
+DISPLAY_DATE_FORMAT = "%B %d, %Y %H:%M"
 
 
 def load_transformed_raw_input(session: GuiSession) -> pl.DataFrame:
@@ -110,7 +111,7 @@ def load_primary_output(session: GuiSession) -> pl.DataFrame:
 
     if OUTPUT_COL_TIMESPAN in df.columns and df[OUTPUT_COL_TIMESPAN].dtype == pl.String:
         df = df.with_columns(
-            pl.col(OUTPUT_COL_TIMESPAN).str.to_datetime("%Y-%m-%d %H:%M:%S")
+            pl.col(OUTPUT_COL_TIMESPAN).str.to_datetime(PRIMARY_OUTPUT_DATETIME_FORMAT)
         )
 
     return df

--- a/gui/dashboards/hashtags/plots.py
+++ b/gui/dashboards/hashtags/plots.py
@@ -12,6 +12,7 @@ import polars as pl
 from analyzers.hashtags.hashtags_base.interface import (
     OUTPUT_COL_GINI,
     OUTPUT_COL_TIMESPAN,
+    PRIMARY_OUTPUT_DATETIME_FORMAT,
 )
 
 MANGO_DARK_ORANGE = "#f3921e"
@@ -51,7 +52,7 @@ def plot_gini_echart(
     series_data = [
         {
             "value": [ts, gini],
-            "raw_ts": ts.strftime("%Y-%m-%d %H:%M"),
+            "raw_ts": ts.strftime(PRIMARY_OUTPUT_DATETIME_FORMAT),
             "display_ts": _format_date_for_axis(ts, is_hourly),
         }
         for ts, gini in zip(
@@ -86,7 +87,7 @@ def plot_gini_echart(
         smooth_series_data = [
             {
                 "value": [ts, gini_s],
-                "raw_ts": ts.strftime("%Y-%m-%d %H:%M"),
+                "raw_ts": ts.strftime(PRIMARY_OUTPUT_DATETIME_FORMAT),
                 "display_ts": _format_date_for_axis(ts, is_hourly),
             }
             for ts, gini_s in zip(

--- a/gui/tests/dashboard/test_dashboards_hashtags.py
+++ b/gui/tests/dashboard/test_dashboards_hashtags.py
@@ -1,0 +1,83 @@
+"""Tests for the hashtags dashboard: chart payload format and click-handler indexing."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import polars as pl
+
+from analyzers.hashtags.hashtags_base.interface import (
+    OUTPUT_COL_GINI,
+    OUTPUT_COL_TIMESPAN,
+    PRIMARY_OUTPUT_DATETIME_FORMAT,
+)
+from gui.dashboards.hashtags.dashboard import HashtagsDashboardPage
+from gui.dashboards.hashtags.plots import plot_gini_echart
+
+
+def test_plot_gini_raw_ts_preserves_seconds() -> None:
+    """raw_ts in chart payload must include seconds to match primary output format."""
+    df = pl.DataFrame(
+        {
+            OUTPUT_COL_TIMESPAN: [datetime(2024, 1, 15, 1, 13, 39)],
+            OUTPUT_COL_GINI: [0.42],
+        }
+    )
+    option = plot_gini_echart(df)
+    raw_ts = option["series"][0]["data"][0]["raw_ts"]
+    assert raw_ts == "2024-01-15 01:13:39"
+
+
+def test_plot_gini_raw_ts_roundtrip() -> None:
+    """raw_ts must parse back to the exact same datetime (no precision loss)."""
+    original = datetime(2024, 3, 20, 17, 45, 59)
+    df = pl.DataFrame(
+        {
+            OUTPUT_COL_TIMESPAN: [original],
+            OUTPUT_COL_GINI: [0.55],
+        }
+    )
+    option = plot_gini_echart(df)
+    raw_ts = option["series"][0]["data"][0]["raw_ts"]
+    parsed = datetime.strptime(raw_ts, PRIMARY_OUTPUT_DATETIME_FORMAT)
+    assert parsed == original
+
+
+def test_get_raw_data_index_matches_non_round_timestamps(
+    gui_session_with_project: MagicMock,
+) -> None:
+    """_get_raw_data_index must find correct index for datetimes with seconds."""
+    page = HashtagsDashboardPage(session=gui_session_with_project)
+    page._df_primary = pl.DataFrame(
+        {
+            OUTPUT_COL_TIMESPAN: [
+                datetime(2024, 1, 15, 1, 13, 39),
+                datetime(2024, 1, 15, 13, 27, 51),
+                datetime(2024, 1, 16, 8, 0, 0),
+            ],
+            OUTPUT_COL_GINI: [0.42, 0.38, 0.51],
+        }
+    )
+    raw_ts = "2024-01-15 01:13:39"
+    assert page._get_raw_data_index(raw_ts) == 0
+
+    raw_ts = "2024-01-15 13:27:51"
+    assert page._get_raw_data_index(raw_ts) == 1
+
+    raw_ts = "2024-01-16 08:00:00"
+    assert page._get_raw_data_index(raw_ts) == 2
+
+
+def test_get_raw_data_index_returns_none_for_mismatch(
+    gui_session_with_project: MagicMock,
+) -> None:
+    """_get_raw_data_index must return None when raw_ts does not match any row."""
+    page = HashtagsDashboardPage(session=gui_session_with_project)
+    page._df_primary = pl.DataFrame(
+        {
+            OUTPUT_COL_TIMESPAN: [datetime(2024, 1, 15, 1, 13, 39)],
+            OUTPUT_COL_GINI: [0.42],
+        }
+    )
+    assert page._get_raw_data_index("2024-01-15 01:13:00") is None
+    assert page._get_raw_data_index("2024-01-15 01:14:39") is None
+    assert page._get_raw_data_index("2024-01-16 01:13:39") is None


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #313
Clicking a data point on the Gini coefficient line plot in the Hashtags Dashboard triggers a `"No hashtag data for this time window"` error. The `raw_ts` chart building truncated seconds from timestamps, causing a precision mismatch when the click handler passed the value back to the analysis filter.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Centralized datetime format as `PRIMARY_OUTPUT_DATETIME_FORMAT` (`%Y-%m-%d %H:%M:%S`) to preserve full precision for consistent data handling
- Updated `plots.py`, `dashboard.py`, `main.py`, and `data.py` to use the constant for payloads while keeping `DISPLAY_DATE_FORMAT` for UI labels only
- Added 4 GUI tests verifying `raw_ts` preserves seconds and `_get_raw_data_index` correctly resolves non-round timestamps

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
