### PR TITLE
fix: drop rows with null timestamps or content in hashtag analysis

### DIFF
--- a/analyzer_interface/context.py
+++ b/analyzer_interface/context.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional, TypeVar, Union
 import polars as pl
 from dash import Dash
 from polars import DataFrame
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from shiny import Inputs, Outputs, Session
 from shiny.ui._navs import NavPanel
 
@@ -100,8 +100,7 @@ class WebPresenterContext(BaseDerivedModuleContext):
         """
         pass
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class SecondaryAnalyzerContext(BaseDerivedModuleContext):
@@ -180,8 +179,7 @@ class ShinyContext(BaseModel):
     Server handler callback to be called by the shiny application instance
     """
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class FactoryOutputContext(BaseModel):
@@ -205,5 +203,4 @@ class FactoryOutputContext(BaseModel):
     API factory dataframe output for React dashboard REST API
     """
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/analyzers/hashtags/hashtags_base/main.py
+++ b/analyzers/hashtags/hashtags_base/main.py
@@ -47,6 +47,14 @@ def hashtag_analysis(data_frame: pl.DataFrame, every="1h") -> pl.DataFrame:
             pl.col(COL_TIME).str.to_datetime().alias(COL_TIME)
         )
 
+    # Filter rows with null timestamps (required for group_by_dynamic)
+    # and null/empty post content (required for string operations)
+    data_frame = data_frame.filter(
+        pl.col(COL_TIME).is_not_null()
+        & pl.col(COL_POST).is_not_null()
+        & (pl.col(COL_POST) != "")
+    )
+
     # define the expressions
     has_hashtag_symbols = (
         pl.col(COL_POST).str.contains("#").any()

--- a/analyzers/hashtags/test_hashtags_base.py
+++ b/analyzers/hashtags/test_hashtags_base.py
@@ -11,10 +11,12 @@ from .hashtags_base.interface import (
     COL_AUTHOR_ID,
     COL_POST,
     COL_TIME,
+    OUTPUT_COL_COUNT,
+    OUTPUT_COL_USERS,
     OUTPUT_GINI,
     interface,
 )
-from .hashtags_base.main import gini, main
+from .hashtags_base.main import gini, hashtag_analysis, main
 from .test_data import test_data_dir
 
 HASHTAGS = [
@@ -81,6 +83,32 @@ def test_gini():
         assert np.allclose(
             [actual], [test_case["expected"]], rtol=1e-2, atol=1e-2
         ), f"Failed test case: {test_case['description']}"
+
+
+def test_hashtag_analysis_handles_nulls():
+    """Test that hashtag_analysis gracefully handles null timestamps and post content."""
+    df = pl.DataFrame(
+        {
+            COL_AUTHOR_ID: ["user1", "user2", "user3", "user4"],
+            COL_TIME: [
+                "2025-01-01 00:00:00",
+                None,
+                "2025-01-01 01:00:00",
+                "2025-01-01 02:00:00",
+            ],
+            COL_POST: ["#hello #world", None, "#hello", ""],
+        }
+    )
+
+    result = hashtag_analysis(df, every="1h")
+
+    all_users = result[OUTPUT_COL_USERS].explode().unique().to_list()
+    assert "user1" in all_users
+    assert "user3" in all_users
+    assert "user2" not in all_users
+    assert "user4" not in all_users
+
+    assert result[OUTPUT_COL_COUNT].sum() == 3
 
 
 def test_hashtag_analyzer():

--- a/app/project_context.py
+++ b/app/project_context.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 import polars as pl
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from analyzer_interface import ParamValue
 from analyzer_interface import UserInputColumn as BaseUserInputColumn
@@ -105,5 +105,4 @@ class UserInputColumn(BaseUserInputColumn):
     def apply_semantic_transform(self):
         return self.semantic.try_convert(self.data)
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/app/shiny.py
+++ b/app/shiny.py
@@ -1,7 +1,7 @@
 from inspect import signature
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from shiny.session import Inputs, Outputs, Session
 from shiny.ui import (
     _navs,
@@ -65,8 +65,7 @@ class LayoutManager(BaseModel):
     title: Optional[str] = "CIB Mango Tree"
     elements: Optional[List[_navs.NavPanel]] = []
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def add(self, element: _navs.NavPanel):
         self.elements.append(element)

--- a/context/__init__.py
+++ b/context/__init__.py
@@ -56,8 +56,7 @@ class PrimaryAnalyzerContext(BasePrimaryAnalyzerContext):
     store: Storage
     input_columns: dict[str, "InputColumnProvider"]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def input(self) -> InputTableReader:
         return PrimaryAnalyzerInputTableReader(
@@ -95,8 +94,7 @@ class PrimaryAnalyzerOutputWriter(TableWriter, BaseModel):
     output_id: str
     store: Storage
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def parquet_path(self):
@@ -109,8 +107,7 @@ class PrimaryAnalyzerInputTableReader(InputTableReader, BaseModel):
     store: Storage
     input_columns: dict[str, InputColumnProvider]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def parquet_path(self):
@@ -133,8 +130,7 @@ class SecondaryAnalyzerContext(BaseSecondaryAnalyzerContext):
     store: Storage
     temp_dir: str
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def base(self) -> AssetsReader:
@@ -179,8 +175,7 @@ class WebPresenterContext(BaseWebPresenterContext):
     store: Storage
     dash_app: Dash
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def base(self) -> AssetsReader:
@@ -212,8 +207,7 @@ class PrimaryAnalyzerOutputReaderGroupContext(AssetsReader, BaseModel):
     analysis: AnalysisModel
     store: Storage
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def table(self, output_id: str) -> TableReader:
         return PrimaryAnalyzerOutputTableReader(
@@ -226,8 +220,7 @@ class PrimaryAnalyzerOutputTableReader(TableReader, BaseModel):
     output_id: str
     store: Storage
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def parquet_path(self):
@@ -239,8 +232,7 @@ class SecondaryAnalyzerOutputReaderGroupContext(AssetsReader, BaseModel):
     secondary_analyzer_id: str
     store: Storage
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def table(self, output_id: str) -> TableReader:
         return SecondaryAnalyzerOutputTableReader(
@@ -257,8 +249,7 @@ class SecondaryAnalyzerOutputTableReader(TableReader, BaseModel):
     output_id: str
     store: Storage
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def parquet_path(self):
@@ -273,8 +264,7 @@ class SecondaryAnalyzerOutputWriter(TableWriter, BaseModel):
     output_id: str
     store: Storage
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def parquet_path(self):

--- a/testing/context.py
+++ b/testing/context.py
@@ -3,7 +3,7 @@ from functools import cached_property
 from tempfile import TemporaryDirectory
 
 import polars as pl
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from analyzer_interface import ParamValue, SecondaryAnalyzerInterface
 from analyzer_interface.context import AssetsReader, InputTableReader
@@ -68,8 +68,7 @@ class TestSecondaryAnalyzerContext(BaseSecondaryAnalyzerContext):
     output_parquet_root_path: str
     primary_param_values: dict[str, ParamValue]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @cached_property
     def base(self) -> AssetsReader:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #284 

The hashtag analyzer crashes with `polars.exceptions.ComputeError: null values in dynamic group_by not supported, fill nulls.` when the input dataset contains null values in the timestamp or post content columns.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a preprocessing filter in `hashtag_analysis()` that silently drops rows with null timestamps, null post content, or empty post content before performing `group_by_dynamic`
- Added `test_hashtag_analysis_handles_nulls()` unit test to prevent regression, verifying that null/empty rows are excluded while valid rows produce correct output
- Follows the same defensive pattern already used by `time_coordination` and `ngrams_base` analyzers

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Rows with null timestamps or empty/null post content are silently dropped. This is consistent with how other analyzers in the codebase handle missing data — posts without timestamps cannot be placed into time windows, and posts without content cannot contain hashtags.
