### PR TITLE
feat: add basic methods to GuiSession for resetting and tracking session state when navigating between pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,18 +23,41 @@ jobs:
           fi
           echo "✓ Version match: v${TAG_VERSION}"
 
-  call-build_exe:
+  audit:
     needs: validate-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked --no-install-project
+
+      - name: Audit dependencies
+        run: uv run pip-audit --skip-editable
+
+  call-build_exe:
+    needs: [validate-version, audit]
     uses: ./.github/workflows/build_exe.yml
     secrets: inherit
     with:
       is_release: true
   call-docs:
-    needs: validate-version
+    needs: [validate-version, audit]
     uses: ./.github/workflows/docs.yml
     secrets: inherit
   release:
-    needs: call-build_exe
+    needs: [call-build_exe, call-docs]
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --no-install-project
 
-      - name: Audit dependencies for known vulnerabilities
-        run: uv run pip-audit --skip-editable
-
       - name: Run tests
         run: uv run pytest
 

--- a/src/cibmangotree/gui/base.py
+++ b/src/cibmangotree/gui/base.py
@@ -10,11 +10,12 @@ This module provides:
 import abc
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, Generator
+from typing import Generator
 
 from nicegui import ui
 from pydantic import BaseModel, ConfigDict
 
+from cibmangotree.gui.components.exit_confirmation import ExitConfirmationDialog
 from cibmangotree.gui.routes import gui_routes
 from cibmangotree.gui.session import GuiSession
 from cibmangotree.gui.theme import gui_colors, gui_urls
@@ -28,6 +29,11 @@ class GuiPage(BaseModel, abc.ABC):
     pattern. Subclasses implement `render_content()` for page-specific UI
     while inheriting consistent header/footer rendering.
 
+    Exit lifecycle:
+    - `on_exit()`: Override to perform cleanup when leaving the page
+    - `requires_exit_confirmation()`: Override to trigger confirmation dialog
+    - `get_exit_confirmation_message()`: Override to customize confirmation text
+
     Attributes:
         session: Session state container with app context
         route: URL route for this page (e.g., "/", "/projects")
@@ -36,7 +42,6 @@ class GuiPage(BaseModel, abc.ABC):
         back_route: Route to navigate when back button clicked
         back_icon: Icon for back button (default: "arrow_back")
         back_text: Optional text label for back button
-        on_page_exit: Optional callback invoked before navigation (back/home buttons)
         show_footer: Whether to render footer
 
     Usage:
@@ -54,6 +59,12 @@ class GuiPage(BaseModel, abc.ABC):
             def render_content(self) -> None:
                 with ui.column().classes("items-center"):
                     ui.label("My page content")
+
+            def requires_exit_confirmation(self) -> bool:
+                return self.session.current_analysis is not None
+
+            def on_exit(self) -> None:
+                self.session.reset_analysis_workflow()
 
         # Register with NiceGUI
         @ui.page("/my_page")
@@ -75,7 +86,6 @@ class GuiPage(BaseModel, abc.ABC):
     back_route: str | None = None
     back_icon: str = "arrow_back"
     back_text: str | None = None
-    on_page_exit: Callable[[], None] | None = None
 
     # Footer configuration
     show_footer: bool = True
@@ -165,19 +175,55 @@ class GuiPage(BaseModel, abc.ABC):
                             on_click=self._handle_home_click,
                         ).props("flat")
 
-    def _handle_back_click(self) -> None:
-        """Handle back button click with optional page exit callback."""
-        if self.on_page_exit:
-            self.on_page_exit()
+    async def _handle_back_click(self) -> None:
+        """Handle back button click with optional exit confirmation."""
+        if self.requires_exit_confirmation():
+            dialog = ExitConfirmationDialog(
+                message=self.get_exit_confirmation_message(),
+            )
+            confirmed = await dialog
+            if not confirmed:
+                return
+
+        self.on_exit()
 
         if self.back_route:
             self.navigate_to(self.back_route)
 
-    def _handle_home_click(self) -> None:
-        """Handle home button click with optional page exit callback."""
-        if self.on_page_exit:
-            self.on_page_exit()
+    async def _handle_home_click(self) -> None:
+        """Handle home button click with optional exit confirmation."""
+        if self.requires_exit_confirmation():
+            dialog = ExitConfirmationDialog(
+                message=self.get_exit_confirmation_message(),
+            )
+            confirmed = await dialog
+            if not confirmed:
+                return
+
+        self.on_exit()
         self.navigate_to("/")
+
+    def on_exit(self) -> None:
+        """Override to perform cleanup when leaving the page.
+
+        Called after exit confirmation (if any) is accepted,
+        before navigation occurs.
+        """
+        pass
+
+    def requires_exit_confirmation(self) -> bool:
+        """Override to trigger confirmation dialog before leaving.
+
+        Returns True to show confirmation, False to navigate directly.
+        """
+        return False
+
+    def get_exit_confirmation_message(self) -> str:
+        """Override to customize the exit confirmation message.
+
+        Only used when requires_exit_confirmation() returns True.
+        """
+        return "Are you sure you want to leave this page?"
 
     def _render_footer(self) -> None:
         """

--- a/src/cibmangotree/gui/components/__init__.py
+++ b/src/cibmangotree/gui/components/__init__.py
@@ -1,15 +1,10 @@
 from .analysis import AnalysisParamsCard
 from .analysis_utils import analysis_label, present_timestamp
 from .choice_fork import two_button_choice_fork_content
+from .exit_confirmation import ExitConfirmationDialog
 from .import_options import ImportOptionsDialog
 from .manage_analyses import ManageAnalysisDialog
 from .manage_projects import ManageProjectsDialog
-from .stepper_steps import (
-    AnalyzerSelectionStep,
-    ColumnMappingStep,
-    ParamsConfigStep,
-    RunAnalysisStep,
-)
 from .toggle import ToggleButton, ToggleButtonGroup
 from .upload.upload_button import UploadButton
 
@@ -21,10 +16,7 @@ __all__ = [
     "ManageAnalysisDialog",
     "ManageProjectsDialog",
     "ImportOptionsDialog",
-    "AnalyzerSelectionStep",
-    "ColumnMappingStep",
-    "ParamsConfigStep",
-    "RunAnalysisStep",
+    "ExitConfirmationDialog",
     "analysis_label",
     "present_timestamp",
     "two_button_choice_fork_content",

--- a/src/cibmangotree/gui/components/exit_confirmation.py
+++ b/src/cibmangotree/gui/components/exit_confirmation.py
@@ -1,0 +1,39 @@
+from nicegui import ui
+
+
+class ExitConfirmationDialog(ui.dialog):
+    """Reusable confirmation dialog for page exit navigation.
+
+    Subclasses ui.dialog to match the pattern used by
+    ManageProjectsDialog and ImportOptionsDialog.
+
+    Usage:
+        dialog = ExitConfirmationDialog(
+            message="You have unsaved changes. Leave anyway?",
+            confirm_text="Leave",
+            cancel_text="Stay"
+        )
+        confirmed = await dialog
+        if confirmed:
+            ui.navigate.to("/home")
+    """
+
+    def __init__(
+        self,
+        message: str = "Are you sure you want to leave?",
+        confirm_text: str = "Leave",
+        cancel_text: str = "Stay",
+    ):
+        super().__init__()
+        with self, ui.card().classes("w-80 items-center"):
+            ui.label(message).classes("text-center q-mb-md")
+            with ui.row().classes("gap-2"):
+                ui.button(
+                    cancel_text,
+                    on_click=lambda: self.submit(False),
+                ).props("flat")
+                ui.button(
+                    confirm_text,
+                    on_click=lambda: self.submit(True),
+                    color="negative",
+                ).props("flat")

--- a/src/cibmangotree/gui/pages/analysis_config_and_run.py
+++ b/src/cibmangotree/gui/pages/analysis_config_and_run.py
@@ -3,7 +3,7 @@ from typing import Any
 from nicegui import ui
 
 from cibmangotree.gui.base import GuiPage
-from cibmangotree.gui.components.stepper_steps import (
+from cibmangotree.gui.pages.analysis_workflow import (
     AnalyzerSelectionStep,
     ColumnMappingStep,
     ParamsConfigStep,

--- a/src/cibmangotree/gui/pages/analysis_config_and_run.py
+++ b/src/cibmangotree/gui/pages/analysis_config_and_run.py
@@ -41,6 +41,17 @@ class AnalysisConfigAndRunPage(GuiPage):
             show_footer=True,
         )
 
+    def requires_exit_confirmation(self) -> bool:
+        if self.session.analysis_loaded_from_storage:
+            return False
+        return self.session.selected_analyzer is not None
+
+    def get_exit_confirmation_message(self) -> str:
+        return "Your analysis has not been saved yet. Leave anyway?"
+
+    def on_exit(self) -> None:
+        self.session.reset_analysis_workflow()
+
     def render_content(self) -> None:
         """Render the stepper with all configuration steps."""
         if not self.require_project():

--- a/src/cibmangotree/gui/pages/analysis_workflow/__init__.py
+++ b/src/cibmangotree/gui/pages/analysis_workflow/__init__.py
@@ -1,0 +1,11 @@
+from .analyzer_step import AnalyzerSelectionStep
+from .column_mapping_step import ColumnMappingStep
+from .params_step import ParamsConfigStep
+from .run_step import RunAnalysisStep
+
+__all__ = [
+    "AnalyzerSelectionStep",
+    "ColumnMappingStep",
+    "ParamsConfigStep",
+    "RunAnalysisStep",
+]

--- a/src/cibmangotree/gui/pages/analysis_workflow/analyzer_step.py
+++ b/src/cibmangotree/gui/pages/analysis_workflow/analyzer_step.py
@@ -1,0 +1,80 @@
+from nicegui import ui
+
+from cibmangotree.gui.components.toggle import ToggleButtonGroup
+from cibmangotree.gui.session import GuiSession
+
+
+class AnalyzerSelectionStep:
+    """Step 1: Select analyzer from available options."""
+
+    def __init__(self, session: GuiSession):
+        self.session = session
+        self.button_group: ToggleButtonGroup | None = None
+
+    @ui.refreshable_method
+    def render(self) -> None:
+        """Render the step content."""
+        analyzers = self.session.app.context.suite.primary_anlyzers
+
+        if not analyzers:
+            ui.label("No analyzers available").classes("text-grey")
+            return
+
+        analyzer_options = {
+            analyzer.name: analyzer.short_description for analyzer in analyzers
+        }
+        analyzer_long_descriptions = {
+            analyzer.name: analyzer.long_description for analyzer in analyzers
+        }
+
+        self.button_group = ToggleButtonGroup()
+
+        with ui.column().classes("items-center w-full"):
+            with ui.element().classes("w-[64rem] max-w-full"):
+                with ui.row().classes("items-center justify-center gap-4 w-full"):
+                    for analyzer_name in analyzer_options.keys():
+                        self.button_group.add_button(analyzer_name)
+
+                with ui.element().classes("pt-12 flex justify-center w-full"):
+                    DEFAULT_TEXT = (
+                        "No analyzer selected. Click button above to select it."
+                    )
+
+                    with ui.card().classes("w-[40rem] shadow-none"):
+                        with ui.scroll_area().classes("max-h-48"):
+                            ui.label().bind_text_from(
+                                target_object=self.button_group,
+                                target_name="selected_text",
+                                backward=lambda text: analyzer_long_descriptions.get(
+                                    text, DEFAULT_TEXT
+                                ),
+                            ).classes("text-grey")
+
+    def is_valid(self) -> bool:
+        """Check if an analyzer is selected."""
+        return (
+            self.button_group is not None
+            and self.button_group.get_selected_text() is not None
+        )
+
+    def save_state(self) -> bool:
+        """Save selection to session. Returns True if successful."""
+        if not self.button_group:
+            return False
+
+        new_selection = self.button_group.get_selected_text()
+
+        if not new_selection:
+            return False
+
+        analyzers = self.session.app.context.suite.primary_anlyzers
+        selected_analyzer = next(
+            (a for a in analyzers if a.name == new_selection), None
+        )
+
+        if not selected_analyzer:
+            return False
+
+        self.session.selected_analyzer = selected_analyzer
+        self.session.selected_analyzer_name = new_selection
+        return True

--- a/src/cibmangotree/gui/pages/analysis_workflow/column_mapping_step.py
+++ b/src/cibmangotree/gui/pages/analysis_workflow/column_mapping_step.py
@@ -1,0 +1,177 @@
+import polars as pl
+from nicegui import ui
+
+from cibmangotree.analyzer_interface import (
+    column_automap,
+    get_data_type_compatibility_score,
+)
+from cibmangotree.gui.session import GuiSession
+
+
+class ColumnMappingStep:
+    """Step 2: Map user columns to analyzer input columns."""
+
+    def __init__(self, session: GuiSession):
+        self.session = session
+        self.column_dropdowns: dict = {}
+        self.preview_container = None
+
+    @ui.refreshable_method
+    def render(self) -> None:
+        """Render the step content with column cards and preview."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+
+        if not analyzer:
+            ui.label("Please select an analyzer first").classes("text-grey")
+            return
+
+        if not project:
+            ui.label("No project selected").classes("text-grey")
+            return
+
+        input_columns = analyzer.input.columns
+        user_columns = project.columns
+
+        draft_column_mapping = column_automap(user_columns, input_columns)
+
+        with (
+            ui.column()
+            .classes("w-full items-center gap-6")
+            .style("max-width: 960px; margin: 0 auto;")
+        ):
+            ui.label("Map Your Data Columns").classes("text-lg font-bold mb-4")
+
+            with ui.row().classes("flex-wrap gap-6 justify-center w-full"):
+                for input_col in input_columns:
+                    self._build_column_card(
+                        input_col, user_columns, draft_column_mapping
+                    )
+
+            self.preview_container = ui.column().classes("w-full")
+            self._update_preview()
+
+    def _build_column_card(self, input_col, user_columns, draft_column_mapping) -> None:
+        """Build a single column mapping card."""
+        with ui.card().classes("w-52 p-4 no-shadow border border-gray-200"):
+            with ui.row().classes("items-center gap-1"):
+                ui.label(input_col.human_readable_name_or_fallback()).classes(
+                    "text-bold"
+                )
+                if input_col.description:
+                    with ui.icon("info").classes("text-grey-6 cursor-pointer"):
+                        ui.tooltip(input_col.description)
+
+            compatible_columns = [
+                user_col
+                for user_col in user_columns
+                if get_data_type_compatibility_score(
+                    input_col.data_type, user_col.data_type
+                )
+                is not None
+            ]
+
+            dropdown_options = {
+                f"{user_col.name}": user_col.name for user_col in compatible_columns
+            }
+
+            default_value = None
+            if input_col.name in draft_column_mapping:
+                mapped_col_name = draft_column_mapping[input_col.name]
+                default_value = next(
+                    (k for k, v in dropdown_options.items() if v == mapped_col_name),
+                    None,
+                )
+
+            dropdown = (
+                ui.select(
+                    options=list(dropdown_options.keys()),
+                    value=default_value,
+                    on_change=lambda: self._update_preview(),
+                )
+                .classes("w-full mt-2")
+                .props("use-chips")
+            )
+
+            self.column_dropdowns[input_col.name] = (dropdown, dropdown_options)
+
+    def _build_preview_df(self) -> pl.DataFrame:
+        """Build preview DataFrame with currently mapped columns."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+
+        if not analyzer or not project:
+            return pl.DataFrame()
+
+        current_mapping = {}
+        for input_col_name, (dropdown, options) in self.column_dropdowns.items():
+            if dropdown.value:
+                current_mapping[input_col_name] = options[dropdown.value]
+
+        tmp_col = list(project.column_dict.values())[0]
+        N_PREVIEW_ROWS = min(5, tmp_col.data.len())
+
+        preview_data = {}
+        for analyzer_col in analyzer.input.columns:
+            col_name = analyzer_col.human_readable_name_or_fallback()
+            user_col_name = current_mapping.get(analyzer_col.name)
+
+            if user_col_name and user_col_name in project.column_dict:
+                user_col = project.column_dict[user_col_name]
+                preview_data[col_name] = user_col.head(
+                    N_PREVIEW_ROWS
+                ).apply_semantic_transform()
+            else:
+                preview_data[col_name] = [None] * N_PREVIEW_ROWS
+
+        return pl.DataFrame(preview_data)
+
+    def _update_preview(self) -> None:
+        """Rebuild preview when dropdown changes."""
+        if self.preview_container is None:
+            return
+
+        self.preview_container.clear()
+        with self.preview_container:
+            preview_df = self._build_preview_df()
+            preview_title = (
+                "Data Preview (first 5 rows)"
+                if len(preview_df) > 5
+                else "Data Preview (all rows)"
+            )
+            ui.label(preview_title).classes("text-sm text-grey-7")
+
+            grid = ui.aggrid.from_polars(
+                preview_df,
+                theme="quartz",
+                auto_size_columns=True,
+            ).classes("w-full h-64")
+            grid.on(
+                "firstDataRendered",
+                lambda: grid.run_grid_method("sizeColumnsToFit"),
+            )
+
+    def is_valid(self) -> bool:
+        """Check if all required columns are mapped."""
+        analyzer = self.session.selected_analyzer
+        if not analyzer:
+            return False
+
+        required_columns = [col.name for col in analyzer.input.columns]
+        mapped_columns = [
+            col_name
+            for col_name, (dropdown, _) in self.column_dropdowns.items()
+            if dropdown.value
+        ]
+
+        return all(col in mapped_columns for col in required_columns)
+
+    def save_state(self) -> bool:
+        """Save column mapping to session."""
+        final_mapping = {}
+        for input_col_name, (dropdown, options) in self.column_dropdowns.items():
+            if dropdown.value:
+                final_mapping[input_col_name] = options[dropdown.value]
+
+        self.session.column_mapping = final_mapping
+        return True

--- a/src/cibmangotree/gui/pages/analysis_workflow/params_step.py
+++ b/src/cibmangotree/gui/pages/analysis_workflow/params_step.py
@@ -1,0 +1,109 @@
+from tempfile import TemporaryDirectory
+
+from nicegui import ui
+
+from cibmangotree.context import (
+    InputColumnProvider,
+    PrimaryAnalyzerDefaultParametersContext,
+)
+from cibmangotree.gui.components import AnalysisParamsCard
+from cibmangotree.gui.session import GuiSession
+
+
+class ParamsConfigStep:
+    """Step 3: Configure analyzer parameters."""
+
+    def __init__(self, session: GuiSession):
+        self.session = session
+        self.params_card: AnalysisParamsCard | None = None
+        self._param_values: dict = {}
+
+    @ui.refreshable_method
+    def render(self) -> None:
+        """Render parameter configuration or 'no params' message."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+        column_mapping = self.session.column_mapping
+
+        if not analyzer:
+            ui.label("Please select an analyzer first").classes("text-grey")
+            return
+
+        if not analyzer.params:
+            ui.label("This analyzer has no configurable parameters.").classes(
+                "text-grey-7"
+            )
+            self.session.analysis_params = {}
+            return
+
+        if not project or not column_mapping:
+            ui.label("Please map columns first").classes("text-grey")
+            return
+
+        with TemporaryDirectory() as temp_dir:
+            default_parameters_context = PrimaryAnalyzerDefaultParametersContext(
+                analyzer=analyzer,
+                store=self.session.app.context.storage,
+                temp_dir=temp_dir,
+                input_columns={
+                    analyzer_column_name: InputColumnProvider(
+                        user_column_name=user_column_name,
+                        semantic=project.column_dict[user_column_name].semantic,
+                    )
+                    for analyzer_column_name, user_column_name in column_mapping.items()
+                },
+            )
+
+            analyzer_decl = self.session.app.context.suite.get_primary_analyzer(
+                analyzer.id
+            )
+
+            if not analyzer_decl:
+                ui.label(f"Analyzer `{analyzer.id}` not found").classes("text-negative")
+                return
+
+            param_values = {
+                **{
+                    param_spec.id: static_param_default_value
+                    for param_spec in analyzer_decl.params
+                    if (static_param_default_value := param_spec.default) is not None
+                },
+                **analyzer_decl.default_params(default_parameters_context),
+            }
+            param_values = {
+                param_id: param_value
+                for param_id, param_value in param_values.items()
+                if param_value is not None
+            }
+
+            self._param_values = param_values
+
+        with (
+            ui.column()
+            .classes("w-full items-center gap-6")
+            .style("max-width: 960px; margin: 0 auto;")
+        ):
+            ui.label(f"Configure {analyzer.name} Parameters").classes(
+                "text-lg font-bold mb-4"
+            )
+
+            self.params_card = AnalysisParamsCard(
+                params=analyzer.params, default_values=self._param_values
+            )
+
+    def is_valid(self) -> bool:
+        """Always valid - params are optional."""
+        return True
+
+    def save_state(self) -> bool:
+        """Save params to session."""
+        if self.params_card:
+            self.session.analysis_params = self.params_card.get_param_values()
+        else:
+            self.session.analysis_params = {}
+        return True
+
+    def has_params(self) -> bool:
+        """Check if analyzer has configurable parameters."""
+        analyzer = self.session.selected_analyzer
+        return analyzer is not None and len(analyzer.params) > 0

--- a/src/cibmangotree/gui/pages/analysis_workflow/run_step.py
+++ b/src/cibmangotree/gui/pages/analysis_workflow/run_step.py
@@ -1,0 +1,265 @@
+from asyncio import sleep
+from multiprocessing import Manager
+from queue import Empty
+from traceback import format_exc
+
+from nicegui import run, ui
+
+from cibmangotree.app.analysis_context import AnalysisContext, AnalysisQueueMessage
+from cibmangotree.gui.base import GuiPage
+from cibmangotree.gui.routes import gui_routes
+from cibmangotree.gui.session import GuiSession
+from cibmangotree.gui.theme import MANGO_DARK_GREEN, MANGO_ORANGE
+
+QUEUE_POLL_INTERVAL = 0.05
+
+
+class RunAnalysisStep:
+    """Step 4: Execute the analysis with progress tracking."""
+
+    def __init__(self, session: GuiSession, page: GuiPage):
+        self.session = session
+        self.page = page
+
+    @ui.refreshable_method
+    def render(self) -> None:
+        """Render the run analysis button and summary."""
+        analyzer = self.session.selected_analyzer
+        column_mapping = self.session.column_mapping
+        params = self.session.analysis_params
+
+        if not analyzer:
+            ui.label("Please select an analyzer first").classes("text-grey")
+            return
+
+        if not column_mapping:
+            ui.label("Please map columns first").classes("text-grey")
+            return
+
+        with (
+            ui.column()
+            .classes("w-full items-center gap-6")
+            .style("max-width: 960px; margin: 0 auto;")
+        ):
+            ui.label("Configuration Summary").classes("text-lg font-bold mb-4")
+
+            with ui.card().classes("w-full p-4 no-shadow border border-gray-200"):
+                with ui.column().classes("gap-2"):
+                    ui.label(
+                        f"Analyzer: {analyzer.name if analyzer else 'Not selected'}"
+                    ).classes("text-sm")
+                    ui.label(
+                        f"Columns: {len(column_mapping) if column_mapping else 0} mapped"
+                    ).classes("text-sm")
+                    ui.label(
+                        f"Parameters: {len(params) if params else 0} configured"
+                    ).classes("text-sm")
+
+            ui.button(
+                "Run Analysis",
+                icon="play_arrow",
+                color="primary",
+                on_click=self._start_analysis,
+            ).classes("text-base")
+
+    def is_valid(self) -> bool:
+        """Check if all prerequisites are configured."""
+        return (
+            self.session.selected_analyzer is not None
+            and self.session.column_mapping is not None
+            and self.session.analysis_params is not None
+        )
+
+    async def _start_analysis(self) -> None:
+        """Opens dialog and runs the analysis in a separate process."""
+        analyzer = self.session.selected_analyzer
+        project = self.session.current_project
+
+        if not analyzer or not project:
+            self.page.notify_error("Missing analyzer or project")
+            return
+
+        try:
+            analysis = project.create_analysis(
+                analyzer.id,
+                self.session.column_mapping,
+                self.session.analysis_params,
+            )
+        except Exception as e:
+            self.page.notify_error(f"Failed to create analysis: {str(e)}")
+            print(f"Analysis creation error:\n{format_exc()}")
+            return
+
+        secondary_analyzers = (
+            self.session.app.context.suite.find_toposorted_secondary_analyzers(analyzer)
+        )
+        secondary_analyzer_ids = [sec.id for sec in secondary_analyzers]
+
+        manager = Manager()
+        queue = manager.Queue()
+        cancel_event = manager.Event()
+
+        input_columns_data = {
+            analyzer_col_name: (
+                user_col_name,
+                project.column_dict[user_col_name].semantic.semantic_name,
+            )
+            for analyzer_col_name, user_col_name in analysis.column_mapping.items()
+        }
+
+        with (
+            ui.dialog().props("persistent") as dialog,
+            ui.card()
+            .classes("items-center justify-center gap-6")
+            .style("width: 600px; max-width: 90vw; padding: 2rem;"),
+        ):
+            analyzer_header = ui.label(analyzer.name).classes("text-xl font-semibold")
+            status_label = (
+                ui.label("Initializing...")
+                .classes("text-base text-medium")
+                .style(f"color: {MANGO_ORANGE}")
+            )
+
+            step_list_container = ui.column().classes("w-full gap-1 mt-4")
+
+            log_container = ui.column().classes("w-full gap-1 mt-2")
+
+            with ui.row().classes("gap-4 mt-4"):
+                cancel_btn = ui.button(
+                    "Cancel Analysis",
+                    icon="stop",
+                    color="secondary",
+                    on_click=lambda: cancel_event.set(),
+                ).props("outline")
+
+                success_btn = ui.button(
+                    "Continue",
+                    icon="arrow_forward",
+                    color="primary",
+                    on_click=lambda: (
+                        dialog.close(),
+                        self.page.navigate_to(gui_routes.post_analysis),
+                    ),
+                )
+                success_btn.set_visibility(False)
+
+        analysis_complete = False
+        step_rows: dict[str, tuple[ui.spinner, ui.icon, ui.label]] = {}
+        current_step_name: str = None
+
+        def _poll_queue():
+            nonlocal analysis_complete, current_step_name
+
+            try:
+                msg_dict = queue.get_nowait()
+            except Empty:
+                return
+
+            msg = AnalysisQueueMessage(**msg_dict)
+
+            if msg.type == "analyzer_start":
+                analyzer_header.text = msg.analyzer_name or "Analyzer"
+                status_label.text = "Analysis starting..."
+                step_rows.clear()
+                current_step_name = None
+
+            elif msg.type == "analyzer_finish":
+                pass
+
+            elif msg.type == "step_start":
+                step_name = msg.step_name or "Processing..."
+
+                if current_step_name and current_step_name in step_rows:
+                    _, _, prev_label = step_rows[current_step_name]
+                    prev_label.classes(add="text-gray-600", remove="text-medium")
+                    prev_label.style("")
+
+                current_step_name = step_name
+                status_label.text = "Running analysis..."
+
+                with step_list_container:
+                    with ui.row().classes("items-center gap-2"):
+                        spinner = ui.spinner("gears", size="sm")
+                        checkmark = ui.icon(
+                            "check_circle", color=MANGO_DARK_GREEN, size="sm"
+                        )
+                        checkmark.set_visibility(False)
+                        label = ui.label(step_name).classes("text-medium")
+                step_rows[step_name] = (spinner, checkmark, label)
+
+            elif msg.type == "step_finish":
+                if current_step_name and current_step_name in step_rows:
+                    spinner, checkmark, label = step_rows[current_step_name]
+                    spinner.set_visibility(False)
+                    checkmark.set_visibility(True)
+                    label.classes(add="text-gray-600", remove="text-medium")
+                    label.style("")
+                    label.text = current_step_name
+                current_step_name = None
+
+            elif msg.type == "step_progress":
+                if current_step_name and current_step_name in step_rows:
+                    _, _, label = step_rows[current_step_name]
+                    progress_pct = (msg.step_progress or 0) * 100
+                    label.text = f"{current_step_name} ({progress_pct:.0f}%)"
+
+            elif msg.type == "log":
+                with log_container:
+                    label = ui.label(msg.message).classes("text-sm")
+                    if msg.progress is not None:
+                        label.text = f"{msg.message} ({msg.progress * 100:.0f}%)"
+
+            elif msg.type == "error":
+                with log_container:
+                    ui.label(f"Error: {msg.message}").classes(
+                        "text-negative font-bold text-sm"
+                    )
+                cancel_btn.disable()
+                analysis_complete = True
+
+            elif msg.type in ("complete", "cancelled"):
+                analysis_complete = True
+                status_label.set_visibility(False)
+                if msg.type == "complete":
+                    self.session.current_analysis = analysis.model
+                    success_btn.set_visibility(True)
+                    self.page.notify_success("Analysis completed!")
+                else:
+                    self.page.notify_warning("Analysis was canceled")
+                cancel_btn.disable()
+
+        async def run_analysis_task():
+            try:
+                result = await run.cpu_bound(
+                    AnalysisContext.run_worker,
+                    analysis.model,
+                    analyzer.id,
+                    analysis.column_mapping,
+                    input_columns_data,
+                    secondary_analyzer_ids,
+                    analysis.app_context.storage,
+                    queue,
+                    cancel_event,
+                )
+                analysis.model.is_draft = result.is_draft
+            except Exception as e:
+                self.page.notify_error(f"Analysis error: {str(e)}")
+                print(f"Analysis error:\n{format_exc()}")
+                with log_container:
+                    ui.label(f"Error: {str(e)}").classes(
+                        "text-negative font-bold text-sm"
+                    )
+                cancel_btn.disable()
+            finally:
+                if analysis.is_draft:
+                    analysis.delete()
+
+        dialog.open()
+        timer = ui.timer(QUEUE_POLL_INTERVAL, _poll_queue)
+
+        await run_analysis_task()
+
+        while not analysis_complete:
+            await sleep(QUEUE_POLL_INTERVAL)
+
+        timer.cancel()

--- a/src/cibmangotree/gui/pages/analyzer_previous.py
+++ b/src/cibmangotree/gui/pages/analyzer_previous.py
@@ -33,6 +33,15 @@ class SelectPreviousAnalyzerPage(GuiPage):
             show_footer=True,
         )
 
+    def requires_exit_confirmation(self) -> bool:
+        return self.session.current_analysis is not None
+
+    def get_exit_confirmation_message(self) -> str:
+        return "Your analysis selection will be lost. Leave anyway?"
+
+    def on_exit(self) -> None:
+        self.session.reset_analysis_workflow()
+
     def render_content(self) -> None:
         """Render previous analysis selection interface."""
         # Ensure a project is selected
@@ -93,6 +102,7 @@ class SelectPreviousAnalyzerPage(GuiPage):
                 )
                 self.session.column_mapping = selected_context.column_mapping
                 self.session.analysis_params = selected_context.backfilled_param_values
+                self.session.analysis_loaded_from_storage = True
 
                 self.navigate_to(gui_routes.post_analysis)
 

--- a/src/cibmangotree/gui/pages/analyzer_select.py
+++ b/src/cibmangotree/gui/pages/analyzer_select.py
@@ -21,6 +21,9 @@ class SelectAnalyzerForkPage(GuiPage):
             show_footer=True,
         )
 
+    def on_exit(self) -> None:
+        self.session.reset_analysis_workflow()
+
     def render_content(self):
         # Main content area - centered vertically
         with self.centered_content():

--- a/src/cibmangotree/gui/pages/dataset_preview.py
+++ b/src/cibmangotree/gui/pages/dataset_preview.py
@@ -34,6 +34,15 @@ class PreviewDatasetPage(GuiPage):
             show_footer=True,
         )
 
+    def requires_exit_confirmation(self) -> bool:
+        return self.session.selected_file is not None
+
+    def get_exit_confirmation_message(self) -> str:
+        return "No project has been created yet. Leave anyway?"
+
+    def on_exit(self) -> None:
+        self.session.reset_project_workflow()
+
     def _selected_file_does_not_exists(self) -> bool:
         return (
             not self.session.selected_file_content_type

--- a/src/cibmangotree/gui/pages/importer.py
+++ b/src/cibmangotree/gui/pages/importer.py
@@ -29,6 +29,20 @@ class ImportDatasetPage(GuiPage):
             show_footer=True,
         )
 
+    def requires_exit_confirmation(self) -> bool:
+        if self.session.project_loaded_from_storage:
+            return False
+        return (
+            self.session.current_project is not None
+            or self.session.selected_file is not None
+        )
+
+    def get_exit_confirmation_message(self) -> str:
+        return "No project has been created yet. Leave anyway?"
+
+    def on_exit(self) -> None:
+        self.session.reset_project_workflow()
+
     def render_content(self) -> None:
         """Render file selection interface."""
         # Page state - store selected file path locally

--- a/src/cibmangotree/gui/pages/project_new.py
+++ b/src/cibmangotree/gui/pages/project_new.py
@@ -14,8 +14,10 @@ class NewProjectPage(GuiPage):
             show_back_button=True,
             back_route="/",
             show_footer=True,
-            on_page_exit=lambda: session.reset_project_workflow(),
         )
+
+    def on_exit(self) -> None:
+        self.session.reset_project_workflow()
 
     def render_content(self) -> None:
         # Main content - centered vertically and horizontally

--- a/src/cibmangotree/gui/pages/project_select.py
+++ b/src/cibmangotree/gui/pages/project_select.py
@@ -22,6 +22,9 @@ class SelectProjectPage(GuiPage):
             show_footer=True,
         )
 
+    def on_exit(self) -> None:
+        self.session.reset_analysis_workflow()
+
     def render_content(self) -> None:
         """Render projects list with selection interface."""
         # Projects list - centered
@@ -64,6 +67,7 @@ class SelectProjectPage(GuiPage):
                             self.session.current_project = project_options[
                                 selected_project.value
                             ]
+                            self.session.project_loaded_from_storage = True
                             self.notify_success(
                                 f"Selected project: {self.session.current_project.display_name}"
                             )

--- a/src/cibmangotree/gui/session.py
+++ b/src/cibmangotree/gui/session.py
@@ -71,8 +71,12 @@ class GuiSession(BaseModel):
 
     def reset_project_workflow(self) -> None:
         """Clear project creation workflow state."""
-        self.new_project_name = None
+        self.current_project = None
         self.selected_file_path = None
+        self.selected_file_name = None
+        self.selected_file = None
+        self.selected_file_content_type = None
+        self.new_project_name = None
         self.import_session = None
 
     def reset_analysis_workflow(self) -> None:
@@ -81,6 +85,7 @@ class GuiSession(BaseModel):
         self.selected_analyzer_name = None
         self.column_mapping = None
         self.current_analysis = None
+        self.analysis_params = None
 
     def validate_project_selected(self) -> bool:
         """Check if a project is currently selected."""

--- a/src/cibmangotree/gui/session.py
+++ b/src/cibmangotree/gui/session.py
@@ -28,6 +28,8 @@ class GuiSession(BaseModel):
         import_session: Active importer session for data preview
         selected_analyzer: ID of selected primary analyzer
         current_analysis: Currently selected/active analysis
+        project_loaded_from_storage: True if project was loaded from disk
+        analysis_loaded_from_storage: True if analysis was loaded from disk
 
     Example:
         ```python
@@ -61,6 +63,10 @@ class GuiSession(BaseModel):
     current_analysis: AnalysisModel | None = None
     analysis_params: dict[str, ParamValue] | None = None
 
+    # Source tracking flags
+    project_loaded_from_storage: bool = False
+    analysis_loaded_from_storage: bool = False
+
     # Allow arbitrary types (for NiceGUI components, ImporterSession, etc.)
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -78,6 +84,7 @@ class GuiSession(BaseModel):
         self.selected_file_content_type = None
         self.new_project_name = None
         self.import_session = None
+        self.project_loaded_from_storage = False
 
     def reset_analysis_workflow(self) -> None:
         """Clear analysis workflow state."""
@@ -86,6 +93,7 @@ class GuiSession(BaseModel):
         self.column_mapping = None
         self.current_analysis = None
         self.analysis_params = None
+        self.analysis_loaded_from_storage = False
 
     def validate_project_selected(self) -> bool:
         """Check if a project is currently selected."""

--- a/src/cibmangotree/gui/tests/pages/test_pages_exit_confirmation.py
+++ b/src/cibmangotree/gui/tests/pages/test_pages_exit_confirmation.py
@@ -1,0 +1,87 @@
+"""Tests for exit confirmation behavior with loaded-from-storage flags."""
+
+from unittest.mock import MagicMock
+
+from cibmangotree.app import App
+from cibmangotree.gui.context import GUIContext
+from cibmangotree.gui.pages.analysis_config_and_run import AnalysisConfigAndRunPage
+from cibmangotree.gui.pages.importer import ImportDatasetPage
+from cibmangotree.gui.session import GuiSession
+
+
+def _make_session() -> GuiSession:
+    app = MagicMock(spec=App)
+    app.list_projects.return_value = []
+    suite = MagicMock()
+    suite.primary_anlyzers = []
+    suite.get_primary_analyzer.return_value = None
+    ctx = MagicMock()
+    ctx.suite = suite
+    ctx.storage = MagicMock()
+    app.context = ctx
+    return GuiSession(context=GUIContext(app=app))
+
+
+def _make_session_with_project() -> GuiSession:
+    project = MagicMock()
+    project.display_name = "Test Project"
+
+    session = _make_session()
+    session.current_project = project
+    return session
+
+
+def test_import_no_confirmation_when_no_state() -> None:
+    session = _make_session()
+    page = ImportDatasetPage(session=session)
+    assert page.requires_exit_confirmation() is False
+
+
+def test_import_confirmation_when_file_selected() -> None:
+    session = _make_session()
+    session.selected_file = MagicMock()
+    page = ImportDatasetPage(session=session)
+    assert page.requires_exit_confirmation() is True
+
+
+def test_import_no_confirmation_when_project_loaded_from_storage() -> None:
+    session = _make_session_with_project()
+    session.project_loaded_from_storage = True
+    page = ImportDatasetPage(session=session)
+    assert page.requires_exit_confirmation() is False
+
+
+def test_import_confirmation_when_project_created_fresh() -> None:
+    session = _make_session_with_project()
+    session.project_loaded_from_storage = False
+    page = ImportDatasetPage(session=session)
+    assert page.requires_exit_confirmation() is True
+
+
+def test_analysis_config_no_confirmation_when_no_state() -> None:
+    session = _make_session()
+    page = AnalysisConfigAndRunPage(session=session)
+    assert page.requires_exit_confirmation() is False
+
+
+def test_analysis_config_confirmation_when_analyzer_selected() -> None:
+    session = _make_session()
+    session.selected_analyzer = MagicMock()
+    page = AnalysisConfigAndRunPage(session=session)
+    assert page.requires_exit_confirmation() is True
+
+
+def test_analysis_config_no_confirmation_when_loaded_from_storage() -> None:
+    session = _make_session_with_project()
+    session.selected_analyzer = MagicMock()
+    session.analysis_loaded_from_storage = True
+    page = AnalysisConfigAndRunPage(session=session)
+    assert page.requires_exit_confirmation() is False
+
+
+def test_analysis_config_confirmation_when_configured_fresh() -> None:
+    session = _make_session_with_project()
+    session.selected_analyzer = MagicMock()
+    session.analysis_loaded_from_storage = False
+    page = AnalysisConfigAndRunPage(session=session)
+    assert page.requires_exit_confirmation() is True

--- a/src/cibmangotree/gui/tests/stepper/test_stepper_analyzer_step.py
+++ b/src/cibmangotree/gui/tests/stepper/test_stepper_analyzer_step.py
@@ -1,9 +1,9 @@
-"""Behavior tests for gui.components.stepper_steps.analyzer_step.AnalyzerSelectionStep."""
+"""Behavior tests for gui.pages.analysis_workflow.analyzer_step.AnalyzerSelectionStep."""
 
 from nicegui import ui
 from nicegui.testing import User
 
-from cibmangotree.gui.components.stepper_steps.analyzer_step import (
+from cibmangotree.gui.pages.analysis_workflow.analyzer_step import (
     AnalyzerSelectionStep,
 )
 from cibmangotree.gui.session import GuiSession

--- a/src/cibmangotree/gui/tests/stepper/test_stepper_column_mapping_step.py
+++ b/src/cibmangotree/gui/tests/stepper/test_stepper_column_mapping_step.py
@@ -1,9 +1,9 @@
-"""Behavior tests for gui.components.stepper_steps.column_mapping_step.ColumnMappingStep."""
+"""Behavior tests for gui.pages.analysis_workflow.column_mapping_step.ColumnMappingStep."""
 
 from nicegui import ui
 from nicegui.testing import User
 
-from cibmangotree.gui.components.stepper_steps.column_mapping_step import (
+from cibmangotree.gui.pages.analysis_workflow.column_mapping_step import (
     ColumnMappingStep,
 )
 from cibmangotree.gui.session import GuiSession

--- a/src/cibmangotree/gui/tests/stepper/test_stepper_params_step.py
+++ b/src/cibmangotree/gui/tests/stepper/test_stepper_params_step.py
@@ -1,11 +1,11 @@
-"""Behavior tests for gui.components.stepper_steps.params_step.ParamsConfigStep."""
+"""Behavior tests for gui.pages.analysis_workflow.params_step.ParamsConfigStep."""
 
 from unittest.mock import MagicMock
 
 from nicegui import ui
 from nicegui.testing import User
 
-from cibmangotree.gui.components.stepper_steps.params_step import ParamsConfigStep
+from cibmangotree.gui.pages.analysis_workflow.params_step import ParamsConfigStep
 from cibmangotree.gui.session import GuiSession
 
 

--- a/src/cibmangotree/gui/tests/stepper/test_stepper_run_step.py
+++ b/src/cibmangotree/gui/tests/stepper/test_stepper_run_step.py
@@ -1,11 +1,11 @@
-"""Behavior tests for gui.components.stepper_steps.run_step.RunAnalysisStep."""
+"""Behavior tests for gui.pages.analysis_workflow.run_step.RunAnalysisStep."""
 
 from unittest.mock import MagicMock
 
 from nicegui import ui
 from nicegui.testing import User
 
-from cibmangotree.gui.components.stepper_steps.run_step import RunAnalysisStep
+from cibmangotree.gui.pages.analysis_workflow.run_step import RunAnalysisStep
 from cibmangotree.gui.session import GuiSession
 
 

--- a/src/cibmangotree/gui/tests/test_session.py
+++ b/src/cibmangotree/gui/tests/test_session.py
@@ -15,12 +15,14 @@ def test_reset_project_workflow_clears_project_import_fields(
     session.new_project_name = "p"
     session.selected_file_path = Path("/tmp/x.csv")
     session.import_session = MagicMock()
+    session.project_loaded_from_storage = True
 
     session.reset_project_workflow()
 
     assert session.new_project_name is None
     assert session.selected_file_path is None
     assert session.import_session is None
+    assert session.project_loaded_from_storage is False
 
 
 def test_reset_analysis_workflow_clears_analysis_fields(mock_app: MagicMock) -> None:
@@ -29,6 +31,7 @@ def test_reset_analysis_workflow_clears_analysis_fields(mock_app: MagicMock) -> 
     session.selected_analyzer_name = "ngrams"
     session.column_mapping = {"a": "b"}
     session.current_analysis = MagicMock()
+    session.analysis_loaded_from_storage = True
 
     session.reset_analysis_workflow()
 
@@ -36,6 +39,7 @@ def test_reset_analysis_workflow_clears_analysis_fields(mock_app: MagicMock) -> 
     assert session.selected_analyzer_name is None
     assert session.column_mapping is None
     assert session.current_analysis is None
+    assert session.analysis_loaded_from_storage is False
 
 
 def test_validate_project_selected_and_file_and_name(mock_app: MagicMock) -> None:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

So far, each GUI page had a `on_exit` parameter that would be provided a callable to define what happens on exit from page (navigate to etc.), but no systematic way to check whether the information input from the user was already saved to disk or not and whether there's a danger it would be lost when navigating to another page (e.g. Clicking "Home" when in the middle of configuring analysis.

Issue Number: #243 

## What is the new behavior?

- Here, we add `ExitConfirmationDialog` class (subclass of `ui.dialog`) that pops up whenever a user leaves the page that was not yet saved, but had some information entered
- We also add `requires_exit_confirmation` `on_exit`, `get_exit_confirmation_message` to `GuiPage` that can be overriden by individual page instances to define what happens when a user navigates back or home
- update `.reset_project_workflow()` and `.reset_analysis_workflow()` methods
- We update all the pages with these methods (might need to be polished)
- We add a new test for this behavior

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
