### PR TITLE
dev: cleanup pyinstaller.spec and add folder removal to build_gui.yml for MacOS

### DIFF
--- a/.github/workflows/build_gui.yml
+++ b/.github/workflows/build_gui.yml
@@ -78,7 +78,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --locked
+        run: uv sync --locked --no-dev
 
       - name: Create macOS keychain
         id: keychain
@@ -129,6 +129,16 @@ jobs:
           ls -lah dist/
           echo "Looking for: CIBMangoTree"
 
+      - name: Clean up redundant onedir folder
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # Remove the intermediate CIBMangoTree/ folder (BUNDLE already created .app)
+          if [ -d "dist/CIBMangoTree" ] && [ ! -L "dist/CIBMangoTree" ]; then
+            rm -rf dist/CIBMangoTree
+            echo "Removed redundant dist/CIBMangoTree/ folder"
+          fi
+
       - name: Create and sign macOS package
         if: runner.os == 'macOS' && inputs.is_release
         env:
@@ -163,6 +173,7 @@ jobs:
         if: runner.os == 'macOS' && inputs.is_release
         run: |
           rm -rf /tmp/cibmangotree
+          rm -rf dist/CIBMangoTree
           rm -rf dist/CIBMangoTree.app
           rm -rf dist/CIBMangoTree_${{matrix.artifact_name}}.zip
 

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -41,14 +41,11 @@ a = Analysis(
     ],
     hiddenimports=[
         'numpy',
-        'numpy.core.multiarray',
         'asyncio',
         'polars',
         'linkify_it',
         'markdown_it',
-        'mdit_py_plugins',
         'mdurl',
-        'uc_micro',
         'pythonjsonlogger',
         'pythonjsonlogger.json',
         # NiceGUI (required for GUI mode)
@@ -57,10 +54,15 @@ a = Analysis(
         'nicegui.events',
         'nicegui.ui',
         'fastapi',
-        'sse_starlette',
     ],  # Include any imports that PyInstaller might miss
+    excludes=[
+        'pytest',
+        'py',
+        'setuptools',
+        'pip',
+        'wheel',
+    ],
     runtime_hooks=[],
-    excludes=[],
 )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently the MacOS build from the build_gui.yml is ~1GB in size, but locally built `.app` bundle is ~425MB. Hypothesis is that we bundled redundant CIBMangoTree folder which double the bundle size.

Issue Number: #243 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
The .app bundle should be half the previous size.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
