### PR TITLE
fix: prefix worker-side imports in run_worker with cibmangotree.* (#338)

### DIFF
--- a/src/cibmangotree/app/analysis_context.py
+++ b/src/cibmangotree/app/analysis_context.py
@@ -120,8 +120,8 @@ class AnalysisContext(BaseModel):
         Returns:
             The updated analysis model (is_draft=False on success)
         """
-        from analyzers import suite
-        from preprocessing.series_semantic import all_semantics
+        from cibmangotree.analyzers import suite
+        from cibmangotree.preprocessing.series_semantic import all_semantics
 
         from .gui_progress_reporter import GUIProgressReporter
 


### PR DESCRIPTION
Two non-prefixed imports inside `AnalysisContext.run_worker` survived the CLI→GUI rename. They only fail in the GUI build because `run_worker` is dispatched via `nicegui.run.cpu_bound`, which spawns a fresh process where only the `cibmangotree.*` namespace is importable — causing the hashtag and n-gram analyzers to crash with `ModuleNotFoundError`.

Fixes #338.

Follow-up test-hardening proposals tracked in #339 (kept out of this PR to keep the diff to two lines).