### PR TITLE
fix: cleanup double zip copying, add permissions to create release

### DIFF
--- a/.github/workflows/build_preview_gui.yml
+++ b/.github/workflows/build_preview_gui.yml
@@ -52,6 +52,8 @@ jobs:
     needs: [get-commit-info, build-preview]
     if: ${{ github.event.inputs.create_release == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v5
@@ -74,6 +76,7 @@ jobs:
               fi
             fi
           done
+          rm -rf artifacts/*/
 
       - name: Create Draft Release
         uses: softprops/action-gh-release@v1
@@ -83,7 +86,7 @@ jobs:
           tag_name: gui-preview-${{ github.event.inputs.version_name }}-${{ needs.get-commit-info.outputs.sha_short }}
           name: "GUI Preview: ${{ github.event.inputs.version_name }}"
           files: |
-            artifacts/**/*
+            artifacts/*.zip
           body: |
             # GUI Preview Build
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

GUI preview doesn't allow to upload artifacts when preview release is triggered.

Issue Number: #243 

## What is the new behavior?

Workflow should allow to upload artifacts to create a draft release

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
