### PR TITLE
Add functionality for "Open Results Folder" button

### DIFF
--- a/src/cibmangotree/__main__.py
+++ b/src/cibmangotree/__main__.py
@@ -5,6 +5,7 @@ Bootstraps core services and launches the GUI.
 
 import argparse
 import logging
+import multiprocessing
 import sys
 from multiprocessing import freeze_support
 from pathlib import Path
@@ -12,6 +13,7 @@ from pathlib import Path
 
 def main() -> None:
     freeze_support()
+    multiprocessing.set_start_method("spawn", force=True)
 
     parser = argparse.ArgumentParser(description="CIB Mango Tree")
     parser.add_argument(

--- a/src/cibmangotree/gui/pages/analysis_post.py
+++ b/src/cibmangotree/gui/pages/analysis_post.py
@@ -41,7 +41,7 @@ class PostAnalysisPage(GuiPage):
             dialog = ExportDialog(analysis_context=ctx)
             await dialog
 
-        async def _open_results_folder(self):
+        async def _open_results_folder():
             if self.session.current_analysis is None:
                 self.notify_warning("No analysis to open. Run an analysis first.")
                 return

--- a/src/cibmangotree/gui/pages/analysis_post.py
+++ b/src/cibmangotree/gui/pages/analysis_post.py
@@ -1,10 +1,13 @@
-from nicegui import ui
+import os
+
+from nicegui import run, ui
 
 from cibmangotree.app.analysis_context import AnalysisContext
 from cibmangotree.gui.base import GuiPage
 from cibmangotree.gui.components import ExportDialog
 from cibmangotree.gui.routes import gui_routes
 from cibmangotree.gui.session import GuiSession
+from cibmangotree.gui.utils import open_directory_explorer
 
 
 class PostAnalysisPage(GuiPage):
@@ -38,6 +41,20 @@ class PostAnalysisPage(GuiPage):
             dialog = ExportDialog(analysis_context=ctx)
             await dialog
 
+        async def _open_results_folder(self):
+            if self.session.current_analysis is None:
+                self.notify_warning("No analysis to open. Run an analysis first.")
+                return
+            results_path = os.path.dirname(
+                self.session.app.context.storage._get_project_primary_output_root_path(
+                    self.session.current_analysis
+                )
+            )
+            try:
+                await run.io_bound(open_directory_explorer, results_path)
+            except OSError as e:
+                self.notify_error(f"Could not open results folder: {e}")
+
         with self.centered_content():
             ui.label("What would you like to do next?").classes("q-mb-lg").style(
                 "font-size: 1.05rem"
@@ -58,6 +75,6 @@ class PostAnalysisPage(GuiPage):
 
                 ui.button(
                     "Open results folder",
-                    on_click=lambda: self.notify_warning("Coming soon!"),
+                    on_click=_open_results_folder,
                     color="primary",
-                ).set_enabled(False)
+                )


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ X] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
- The "Open Results Folder" button is disabled.
- Analyses freeze when run on Linux.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The "Open Results Folder" button now opens the directory containing primary and secondary analyses outputs, along with any exports.
- Analyses run as expected on both Linux and Windows

## Does this introduce a breaking change?

- [ ] Yes
- [ X] No
