### PR TITLE
docs: cleanup references to CLI in docs, add GUI reference section (+ small header fix and test.yml update)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,17 @@ on: pull_request
 
 jobs:
   test:
-    name: PyTest Suite
-    runs-on: ubuntu-latest
+    name: PyTest Suite (${{ matrix.platform_name }})
+    strategy:
+      matrix:
+        include:
+          - platform_name: Ubuntu
+            os: ubuntu-latest
+          - platform_name: MacOS Arm64
+            os: macos-15
+          - platform_name: Windows
+            os: windows-2022
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -27,6 +36,7 @@ jobs:
         run: uv run pytest
 
   test_build_gui:
+    name: Executable Build
     uses: ./.github/workflows/build_gui.yml
     secrets: inherit
     with:

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,25 @@
 """Root pytest hooks: NiceGUI plugins must load from top-level conftest (pytest policy)."""
 
+import logging
+
+import pytest
+
 pytest_plugins = (
     "nicegui.testing.general_fixtures",
     "nicegui.testing.user_plugin",
 )
+
+
+@pytest.fixture(autouse=True)
+def cleanup_logging():
+    """Close and remove all logging handlers after each test.
+
+    Prevents Windows file-lock errors when TemporaryDirectory tries to delete
+    log files that are still held open by RotatingFileHandler.
+    """
+    yield
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        handler.close()
+        root_logger.removeHandler(handler)
+    root_logger.setLevel(logging.WARNING)

--- a/docs/guides/contributing/analyzers.md
+++ b/docs/guides/contributing/analyzers.md
@@ -95,8 +95,7 @@ The main function receives a context object with access to input data and output
 
 ```python
 import polars as pl
-from cibmangotree.analyzer_interface.context import PrimaryAnalyzerContext
-from cibmangotree.terminal_tools import ProgressReporter
+from cibmangotree.analyzer_interface.context import PrimaryAnalyzerContext, NullProgressReporter
 
 def main(context: PrimaryAnalyzerContext):
     # Read and preprocess input data
@@ -107,8 +106,11 @@ def main(context: PrimaryAnalyzerContext):
     fudge_factor = context.params.get("fudge_factor")
     assert isinstance(fudge_factor, int), "Fudge factor must be an integer"
     
+    # Get progress reporter (provided by context, or fall back to no-op)
+    progress = context.progress_reporter or (lambda name: NullProgressReporter(name))
+    
     # Perform analysis with progress reporting
-    with ProgressReporter("Counting characters") as progress:
+    with progress("Counting characters") as reporter:
         df_count = df_input.select(
             pl.col("message_id"),
             pl.col("message_text")
@@ -116,7 +118,7 @@ def main(context: PrimaryAnalyzerContext):
             .add(fudge_factor)
             .alias("character_count")
         )
-        progress.update(1.0)
+        reporter.update(1.0)
     
     # Write output to specified path
     df_count.write_parquet(context.output("character_count").parquet_path)

--- a/docs/guides/design-philosophy/architecture.md
+++ b/docs/guides/design-philosophy/architecture.md
@@ -1,7 +1,7 @@
 Before contributing please refer to our [**Github Workflow**](../contributing/github_workflow.md)
 
 ## Application Design Overview
-The CIB 🥭 application is a terminal-based tool for performing data analysis and visualization. It is designed to be modular and extensible, allowing developers to contribute new analysis modules and visualization components while providing a consistent user experience around data import, preprocessing, and output generation.
+The CIB 🥭 application is a GUI-based tool for performing data analysis and visualization. It is designed to be modular and extensible, allowing developers to contribute new analysis modules and visualization components while providing a consistent user experience around data import, preprocessing, and output generation.
 
 This design is motivated by a common pain point when moving from a data analysis script for private use to a tool that can be shared with others: A script for private consumption carries assumptions about the desired input and output data format and structure that are convenient to its author. When such a script is made available to others, debates on these aspects often arise. For a suite of analyses that this project aims to offer, if left decentralized, this debate can lead to inconsistent UX offerings across analyses, code duplication, and even bugs.
 
@@ -12,7 +12,7 @@ The architecture of the CIB 🥭 application is designed to address this problem
 The application has three "domains":
 - The [**Core**](./core-domain.md) domain is responsible for workspace management, user flow, and integration of analysis runs and data import/export in a generic sense. It has three parts that correspond loosely to the MVC paradigm.
   - The **Application** defines the workspace logic and exposes generic capabilities for importing and exporting data as well as analyses and dashboards. This is the "controller" part.
-  - The **Terminal** Components render the terminal interface and handle user input. This is the "view" part.
+  - The **GUI** Components render the graphical interface and handle user input. This is the "view" part.
   - The **Storage IO** persists the workspace data and is responsible for reading and writing data. This is the "model" part.
 
   The core application provides the context necessary for the other domains to function in a way that allows them to be agnostic about the specifics of the workspace and user flow.
@@ -25,7 +25,7 @@ The application has three "domains":
 
 ```mermaid
 flowchart TD
-  terminal["Terminal (core)"]
+  gui["GUI (core)"]
   application["Application (core)"]
   storage["Storage (core)"]
 
@@ -34,7 +34,7 @@ flowchart TD
 
   content["Analyzers/Web Presenters (content)"]
 
-  terminal --> application
+  gui --> application
   application --> storage
 
   application --> importers

--- a/docs/guides/design-philosophy/core-domain.md
+++ b/docs/guides/design-philosophy/core-domain.md
@@ -4,7 +4,7 @@
 
 The Application lives inside the `app` directory in the project root. This is responsible for defining and executing all capabilities of the application's workspace. Any extension or modification of the application's workspace capabilities should be done here.
 
-The application code should be free of specific storage implementation and be agnostic about the specifics of the terminal interface and the available analyzers.
+The application code should be free of specific storage implementation and be agnostic about the specifics of the GUI interface and the available analyzers.
 
 Here's what the entrypoint for the application module looks like
 
@@ -20,32 +20,29 @@ from .project_context import ProjectContext
 from .settings_context import SettingsContext
 ```
 
-### Terminal Components
+### GUI Components
 
-The Terminal Components live inside the `terminal_tools` inside the project root. Their main responsibility is user flow, rendering the terminal interface, and handling user input.
+The GUI Components live inside the `gui` directory inside the project root. Their main responsibility is user flow, rendering the graphical interface using NiceGUI, and handling user input.
 
 The user flow understandably depends on the set of capabilities offered by the [Application](#application), so an adjustment there may require an adjustment here.
 
-Here's what the entrypoint for the termnal module looks like
+Here's what the entrypoint for the gui module looks like
 
-**./terminal_tools/__init__.py**
+**./gui/__init__.py**
 
 ```python
-from .progress import ProgressReporter
-from .utils import (
-    clear_printed_lines,
-    clear_terminal,
-    draw_box,
-    enable_windows_ansi_support,
-    open_directory_explorer,
-    print_ascii_table,
-    wait_for_key,
-)
+"""
+GUI components using NiceGUI for desktop application interface.
+"""
+
+from .main_workflow import gui_main
+
+__all__ = ["gui_main"]
 ```
 
 ### Storage IO
 
-The Storage IO lives Inside the `storage` directory inside the project root. It is responsible for interacting directly with the file system where the workspace data and data files are stored. It makes decisions on paths, intermediate file formats, and database schema and implementation. It should know as little as possible about how the data is used and should be agnostic about the specifics of the terminal interface and the available analyzers.
+The Storage IO lives Inside the `storage` directory inside the project root. It is responsible for interacting directly with the file system where the workspace data and data files are stored. It makes decisions on paths, intermediate file formats, and database schema and implementation. It should know as little as possible about how the data is used and should be agnostic about the specifics of the GUI interface and the available analyzers.
 
 Here's what the entrypoint for the storage module looks like
 

--- a/docs/guides/design-philosophy/edge-domain.md
+++ b/docs/guides/design-philosophy/edge-domain.md
@@ -4,7 +4,7 @@ The Edge domain governs data import and export.
 
 ### Importers
 
-The Importers live inside the `importing` directory inside the project root. Each importer offers a new way to import data into the workspace. The importers should be agnostic about the available analyzers. However, the Importers currently provide a terminal user flow so that their options can be customized by the user—a necessity since each importer may expose different sets of options and may have different UX approaches for their configuration.
+The Importers live inside the `importing` directory inside the project root. Each importer offers a new way to import data into the workspace. The importers should be agnostic about the available analyzers. The Importers provide a GUI user flow so that their options can be customized by the user—a necessity since each importer may expose different sets of options and may have different UX approaches for their configuration.
 
 The importers eventually write data to a parquet file, whose path is provisioned by the application.
 

--- a/docs/guides/get-started/installation.md
+++ b/docs/guides/get-started/installation.md
@@ -76,13 +76,14 @@ Choose your preferred method for setting up your development environment:
 
     ```bash
     # Create virtual environment
+    # this creates a hidden `.venv` folder
     uv venv
 
     # Activate virtual environment (macOS/Linux)
-    source venv/bin/activate
+    source .venv/bin/activate
 
     # OR: if using Windows and PowerShell
-    # venv\Scripts\activate
+    # .venv\Scripts\activate
 
     # Install development dependencies
     uv sync --group dev
@@ -148,13 +149,13 @@ No-op flag detected. All runtime imports loaded successfully.
 
 ### Basic Usage
 
-Once you have activated the environment and installed dependencies, run the application from project root:
+Once you have activated the environment and installed dependencies, run the application using `cibmt` command:
 ```bash
 # Start the application
 cibmt
 ```
 
-Alternatively, use the full command:
+Alternatively, use the long-version command:
 ```bash
 cibmangotree
 ```

--- a/docs/guides/get-started/installation.md
+++ b/docs/guides/get-started/installation.md
@@ -8,7 +8,7 @@ You will need the following software installed in order to get started with sett
 | --- | --- |
 | Python >= 3.12 | Required for all features to work correctly |
 | Git | Required for version control and contributing |
-| command line/terminal | Application runs in terminal |   
+| command line/terminal | Used to launch the application (opens in browser) |   
 
 !!! example
     If you haven't installed git and/or python yet refer to the following links for instructions:  
@@ -136,23 +136,30 @@ pre-commit install
 ### 4. Verify installation
 
 ```bash
-python -m cibmangotree --noop
+cibmt --noop
 ```
 
-If all went well, you should see: 
+If all went well, you should see:
 ```bash
-No-op flag detected. Exiting successfully.
+No-op flag detected. All runtime imports loaded successfully.
 ```
 
 ## Starting the Application
 
 ### Basic Usage
 
-Once you have activated the environment and installed dependencies, run the application from project root:  
+Once you have activated the environment and installed dependencies, run the application from project root:
 ```bash
 # Start the application
-python -m cibmangotree
+cibmt
 ```
+
+Alternatively, use the full command:
+```bash
+cibmangotree
+```
+
+The application opens in a standalone window on macOS, or in your default browser on Windows.
 
 ## Project storage
 

--- a/docs/guides/get-started/overview.md
+++ b/docs/guides/get-started/overview.md
@@ -2,24 +2,18 @@
 
 CIB Mango Tree is a Python-based, open source toolkit for detecting coordinated inauthentic behavior (CIB) in social media datasets. It is designed for researchers, data journalists, fact-checkers, and watchdogs working to identify manipulation and inauthentic activity online.
 
-Through an interactive terminal interface, users can import datasets, check data quality, create analysis projects, and explore results in interactive dashboards without having to writing code. This makes peer-reviewed CIB analysis methods accessible to users with little to no programming experience.
+Through an interactive graphical interface (GUI), users can import datasets, check data quality, create analysis projects, and explore results in interactive dashboards without having to writing code. This makes peer-reviewed CIB analysis methods accessible to users with little to no programming experience.
 
-!["Application welcome screen and logo in the terminal"](../../img/cibmt_splash_logo.png)
+!["Application welcome screen and logo"](../../img/cibmt_welcome_screen.png)
 /// caption
 The welcome screen of the application
 ///
 
 ## Roadmap
 
-### Graphical user interface transition
+### CLI and Shiny removal
 
-We are developing a graphical user interface (GUI) built with [NiceGUI](https://nicegui.io/), which will replace both the current terminal (CLI) interface and Shiny-based dashboards. This transition aims to provide a more intuitive experience for data exploration and visualization. We anticipate to make the GUI available as part of the next minor release (v0.11.0).
-
-!!! tip
-    
-    GUI development is currently underway on the `gui-prototype` branch.
-
-After the GUI release, the CLI and Shiny dashboards will be deprecated and eventually removed in a future major version.
+The terminal-based workflow and Shiny dashboards were removed in version v0.11.0. The graphical user interface (GUI) built with [NiceGUI](https://nicegui.io/) is now the primary interface for data exploration and visualization.
 
 ## Tech Stack
 
@@ -27,7 +21,7 @@ CIB Mango Tree relies on the following packages and data science tooling from th
 
 | Domain | Technologies |
 |----------|--------------|
-| Core | Python 3.12, Inquirer (TUI), TinyDB (metadata), Starlette & Uvicorn (web-server) |
+| Core | Python 3.12, NiceGUI (GUI), TinyDB (metadata), Starlette & Uvicorn (web-server) |
 | Data | Polars/Pandas, PyArrow, Parquet files |
 | Web | Dash, Shiny for Python, Plotly |
 | Dev Tools | Black, isort, pytest, PyInstaller |

--- a/docs/guides/get-started/overview.md
+++ b/docs/guides/get-started/overview.md
@@ -21,7 +21,6 @@ CIB Mango Tree relies on the following packages and data science tooling from th
 
 | Domain | Technologies |
 |----------|--------------|
-| Core | Python 3.12, NiceGUI (GUI), TinyDB (metadata), Starlette & Uvicorn (web-server) |
-| Data | Polars/Pandas, PyArrow, Parquet files |
-| Web | Dash, Shiny for Python, Plotly |
+| Core | Python 3.12, Polars, NiceGUI (GUI), ECharts|
+| Data | PyArrow, Parquet files, TinyDB |
 | Dev Tools | Black, isort, pytest, PyInstaller |

--- a/docs/license.md
+++ b/docs/license.md
@@ -4,6 +4,5 @@ hide:
 - feedback
 ---
 
-```
+
 --8<-- "LICENSE"
-```

--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -1,3 +1,0 @@
-:::cibmangotree.components
-    options:
-        show_submodules: true

--- a/docs/reference/gui.md
+++ b/docs/reference/gui.md
@@ -1,0 +1,39 @@
+::: cibmangotree.gui.main_workflow
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.base
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.context
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.session
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.routes
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.theme
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.components
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.pages
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.dashboards
+    options:
+      group_by_category: false
+
+::: cibmangotree.gui.utils
+    options:
+      group_by_category: false

--- a/docs/reference/terminal_tools.md
+++ b/docs/reference/terminal_tools.md
@@ -1,5 +1,0 @@
-# Terminal tools
-
-:::cibmangotree.terminal_tools
-    options:
-        show_submodules: true

--- a/src/cibmangotree/app/analysis_context.py
+++ b/src/cibmangotree/app/analysis_context.py
@@ -13,7 +13,7 @@ from cibmangotree.context import (
     PrimaryAnalyzerContext,
     SecondaryAnalyzerContext,
 )
-from cibmangotree.storage import AnalysisModel
+from cibmangotree.storage import AnalysisModel, Storage
 
 from .app_context import AppContext
 from .project_context import ProjectContext
@@ -96,7 +96,7 @@ class AnalysisContext(BaseModel):
         column_mapping: dict[str, str],
         input_columns_data: dict[str, tuple[str, str]],
         secondary_analyzer_ids: list[str],
-        storage,
+        storage: Storage,
         queue: Queue,
         cancel_event: Event,
     ) -> AnalysisModel:

--- a/src/cibmangotree/app/test_logger.py
+++ b/src/cibmangotree/app/test_logger.py
@@ -14,6 +14,15 @@ import pytest
 from cibmangotree.app.logger import get_logger, setup_logging
 
 
+def _close_logging_handlers():
+    """Close and remove all root logger handlers to release file locks on Windows."""
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        handler.close()
+        root_logger.removeHandler(handler)
+    root_logger.setLevel(logging.WARNING)
+
+
 class TestSetupLogging:
     """Test cases for the setup_logging function."""
 
@@ -30,6 +39,8 @@ class TestSetupLogging:
             # Directory should be created
             assert log_file_path.parent.exists()
 
+            _close_logging_handlers()
+
     def test_setup_logging_configures_root_logger(self):
         """Test that setup_logging configures the root logger with correct level."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -39,6 +50,8 @@ class TestSetupLogging:
 
             root_logger = logging.getLogger()
             assert root_logger.level == logging.DEBUG
+
+            _close_logging_handlers()
 
     def test_setup_logging_configures_handlers(self):
         """Test that setup_logging configures both console and file handlers."""
@@ -72,6 +85,8 @@ class TestSetupLogging:
             # File handler should exist and be set to INFO level
             assert file_handler is not None
             assert file_handler.level == logging.INFO
+
+            _close_logging_handlers()
 
     def test_console_handler_only_shows_errors(self):
         """Test that console handler only shows ERROR and CRITICAL messages."""
@@ -116,6 +131,8 @@ class TestSetupLogging:
                 # Restore original stderr
                 sys.stderr = original_stderr
 
+            _close_logging_handlers()
+
     def test_file_handler_logs_info_and_above(self):
         """Test that file handler logs INFO and above messages when set to INFO level."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -147,6 +164,8 @@ class TestSetupLogging:
                 assert "Error message" in log_content
                 assert "Critical message" in log_content
                 assert "Debug message" not in log_content
+
+            _close_logging_handlers()
 
     def test_log_format_is_json(self):
         """Test that log messages are formatted as JSON."""
@@ -180,6 +199,8 @@ class TestSetupLogging:
                                 assert "app_version" in log_entry
                             except json.JSONDecodeError:
                                 pytest.fail(f"Log line is not valid JSON: {line}")
+
+            _close_logging_handlers()
 
 
 class TestGetLogger:
@@ -247,6 +268,8 @@ class TestIntegration:
                     ]  # renamed field
                     assert log_entry["app_version"] == "integration_test_version"
 
+            _close_logging_handlers()
+
 
 class TestContextEnrichment:
     """Test cases for context enrichment features."""
@@ -275,6 +298,8 @@ class TestContextEnrichment:
                     assert isinstance(log_entry["process_id"], int)
                     assert isinstance(log_entry["thread_id"], int)
 
+            _close_logging_handlers()
+
     def test_third_party_logger_levels(self):
         """Test that third-party loggers are set to WARNING level."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -295,6 +320,8 @@ class TestContextEnrichment:
             # Application loggers should inherit root level (DEBUG)
             app_logger = logging.getLogger("app")
             assert app_logger.level == logging.DEBUG
+
+            _close_logging_handlers()
 
     def test_cli_level_controls_file_handler(self):
         """Test that CLI log level properly controls file handler level."""
@@ -317,6 +344,8 @@ class TestContextEnrichment:
             # File handler level should match the CLI level
             assert file_handler.level == logging.DEBUG
 
+            _close_logging_handlers()
+
     def test_global_exception_handler_setup(self):
         """Test that global exception handler is installed."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -334,3 +363,5 @@ class TestContextEnrichment:
             finally:
                 # Restore original handler
                 sys.excepthook = original_excepthook
+
+            _close_logging_handlers()

--- a/src/cibmangotree/gui/README.md
+++ b/src/cibmangotree/gui/README.md
@@ -10,10 +10,10 @@ The `/gui` module provides a desktop application interface for CIB Mango Tree, b
 
 ## Running in Development Mode
 
-If you've setup the [development environment](https://civictechdc.github.io/cib-mango-tree/guides/get-started/installation/#setting-up-development-environment), navigate to the root folder and launch the gui entry point:
+If you've setup the [development environment](https://civictechdc.github.io/cib-mango-tree/guides/get-started/installation/#setting-up-development-environment), launch the gui entry point with the `cibmt` (or `cibmangotree`) command:
 
 ```
-python cibmangotree_gui.py
+cibmt
 ```
 
 Both initialize the `App` instance and call `gui_main(app=app)`. NiceGUI starts a local uvicorn server and opens a native desktop window. Set `reload=True` in `ui.run()` inside `main_workflow.py` to enable hot-reloading during development.
@@ -68,6 +68,7 @@ Each analyzer gets its own dashboard page inheriting `BaseDashboardPage` (which 
 Currently implemented:
 
 - `ngrams.py` — `NgramsDashboardPage` for the n-grams analyzer
+- `hashtags.py` — `NgramsDashboardPage` for the n-grams analyzer
 
 Planned but not yet implemented: hashtags, temporal.
 

--- a/src/cibmangotree/gui/components/export_outputs.py
+++ b/src/cibmangotree/gui/components/export_outputs.py
@@ -5,7 +5,7 @@ import threading
 from typing import Literal
 
 from nicegui import run, ui
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from cibmangotree.app import AnalysisContext, AnalysisOutputContext
 from cibmangotree.gui.theme import MANGO_DARK_GREEN
@@ -23,7 +23,7 @@ class ExportProgressMessage(BaseModel):
         "output_finish",
         "output_error",
         "all_complete",
-    ]
+    ] = Field(...)
     name: str | None = None
     index: int | None = None
     total: int | None = None

--- a/src/cibmangotree/gui/components/import_options.py
+++ b/src/cibmangotree/gui/components/import_options.py
@@ -33,7 +33,7 @@ class ImportOptionsDialog(ui.dialog):
 
         Args:
             import_session: Current import session with detected settings
-            selected_file_path: Path to the file being imported
+            selected_file: BytesIO buffer of the file being imported
             on_retry: Callback function called when user clicks "Retry Import"
                      with the updated import session as parameter
         """

--- a/src/cibmangotree/gui/context.py
+++ b/src/cibmangotree/gui/context.py
@@ -2,7 +2,7 @@
 GUI context - similar to ViewContext but for NiceGUI.
 """
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from cibmangotree.app import App
 
@@ -10,5 +10,5 @@ from cibmangotree.app import App
 class GUIContext(BaseModel):
     """Context for GUI mode, wrapping the App instance."""
 
-    app: App
+    app: App = Field(...)
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/cibmangotree/gui/dashboards/ngrams/plots.py
+++ b/src/cibmangotree/gui/dashboards/ngrams/plots.py
@@ -8,7 +8,7 @@ They have no dependency on Shiny, Dash, or NiceGUI.
 import random
 
 import polars as pl
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from cibmangotree.analyzers.ngrams.ngrams_base.interface import (
     COL_NGRAM_ID,
@@ -37,10 +37,10 @@ TAB_10_PALETTE = [
 class SamplingMetadata(BaseModel):
     """Metadata about data sampling applied before visualization."""
 
-    total_count: int
-    sampled_count: int
-    is_sampled: bool
-    strategy: str
+    total_count: int = Field(...)
+    sampled_count: int = Field(...)
+    is_sampled: bool = Field(...)
+    strategy: str = Field(...)
 
     @property
     def sampling_message(self) -> str:

--- a/src/cibmangotree/gui/pages/analysis_post.py
+++ b/src/cibmangotree/gui/pages/analysis_post.py
@@ -15,7 +15,7 @@ class PostAnalysisPage(GuiPage):
         super().__init__(
             session=session,
             route=gui_routes.post_analysis,
-            title=f"{session.current_project.display_name}: Configure Parameters",
+            title=f"{session.current_project.display_name}: Analysis Results",
             show_back_button=True,
             back_route=gui_routes.configure_analysis,
             show_footer=True,

--- a/src/cibmangotree/gui/theme.py
+++ b/src/cibmangotree/gui/theme.py
@@ -41,8 +41,8 @@ class GuiConstants(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    colors: GuiColors
-    urls: GuiURLS
+    colors: GuiColors = Field(...)
+    urls: GuiURLS = Field(...)
 
 
 # Singleton instances for easy access in other modules

--- a/src/cibmangotree/services/tokenizer/basic/patterns.py
+++ b/src/cibmangotree/services/tokenizer/basic/patterns.py
@@ -7,7 +7,10 @@ regex and re modules.
 """
 
 import re
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
+
+if TYPE_CHECKING:
+    from ..core.types import TokenizerConfig
 
 # Try to use the more powerful regex module, fall back to re
 try:
@@ -172,7 +175,7 @@ class TokenizerPatterns:
             raise KeyError(f"Pattern '{pattern_name}' not found")
         return self._patterns[pattern_name]
 
-    def get_comprehensive_pattern(self, config) -> Any:
+    def get_comprehensive_pattern(self, config: "TokenizerConfig") -> Any:
         """
         Build comprehensive tokenization pattern based on configuration.
 
@@ -248,7 +251,7 @@ class TokenizerPatterns:
         _comprehensive_pattern_cache[cache_key] = compiled_pattern
         return compiled_pattern
 
-    def get_exclusion_pattern(self, config) -> Any:
+    def get_exclusion_pattern(self, config: "TokenizerConfig") -> Any:
         """
         Build pattern to identify and skip excluded entities in text.
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -46,6 +46,7 @@ nav = [
         "reference/storage.md",
         "reference/testing.md",
         "reference/tokenizer.md",
+        "reference/gui.md",
     ]},
 ]
 
@@ -87,9 +88,11 @@ paths = ["src"]
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
 
+[project.markdown_extensions.toc]
+permalink = true
+
 [project.plugins.mkdocstrings.handlers.python.options]
 docstring_style = "google"
-extensions = ["griffe_pydantic"]
 filters = ["!^_[^_]", "!^test_"]
 heading_level = 2
 parameter_headings = true

--- a/zensical.toml
+++ b/zensical.toml
@@ -37,12 +37,10 @@ nav = [
             "guides/design-philosophy/content-domain.md",
         ]},
     ]},
-    {"Reference (CLI)" = [
+    {"Reference" = [
         "reference/analyzer_interface.md",
-        "reference/components.md",
         "reference/app.md",
         "reference/preprocessing.md",
-        "reference/terminal_tools.md",
         "reference/importing.md",
         "reference/meta.md",
         "reference/storage.md",

--- a/zensical.toml
+++ b/zensical.toml
@@ -88,6 +88,8 @@ paths = ["src"]
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
 
+[project.markdown_extensions.pymdownx.snippets]
+
 [project.markdown_extensions.toc]
 permalink = true
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Docs (https:civictechdc.github.io/cib-mango-tree) need to be updated to reflect our transition from the CLI to the GUI interface.

Issue Number: #243 

## What is the new behavior?


- Updated Overview and Installation pages
- Update Design philosophy pages and replaced CLI with GUI
- Updated README.md
- smaller header fix in one of the pages
- update `test.yml` to run on MacOS Arm64 and Windows palatforms

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
