### PR TITLE
ux: add .project_just_created in GuiSession and notification when project is successfully created

### DIFF
--- a/src/cibmangotree/gui/pages/analysis_config_and_run.py
+++ b/src/cibmangotree/gui/pages/analysis_config_and_run.py
@@ -57,6 +57,12 @@ class AnalysisConfigAndRunPage(GuiPage):
         if not self.require_project():
             return
 
+        if self.session.project_just_created and self.session.current_project:
+            self.session.project_just_created = False
+            self.notify_success(
+                f"Project '{self.session.current_project.display_name}' created successfully!"
+            )
+
         with self.centered_content(max_width="1200px", justify="start", padding="2rem"):
             with (
                 ui.stepper()

--- a/src/cibmangotree/gui/pages/dataset_preview.py
+++ b/src/cibmangotree/gui/pages/dataset_preview.py
@@ -145,6 +145,7 @@ class PreviewDatasetPage(GuiPage):
 
                     # Store project in session
                     self.session.current_project = project
+                    self.session.project_just_created = True
 
                     # Navigate to analyzer selection
                     self.navigate_to(gui_routes.configure_analysis)

--- a/src/cibmangotree/gui/session.py
+++ b/src/cibmangotree/gui/session.py
@@ -65,6 +65,7 @@ class GuiSession(BaseModel):
 
     # Source tracking flags
     project_loaded_from_storage: bool = False
+    project_just_created: bool = False
     analysis_loaded_from_storage: bool = False
 
     # Allow arbitrary types (for NiceGUI components, ImporterSession, etc.)
@@ -85,6 +86,7 @@ class GuiSession(BaseModel):
         self.new_project_name = None
         self.import_session = None
         self.project_loaded_from_storage = False
+        self.project_just_created = False
 
     def reset_analysis_workflow(self) -> None:
         """Clear analysis workflow state."""


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

After a project is created, no notification is shown to the user.

Issue Number: #362 

## What is the new behavior?

- new `.project_just_created` attribute is added to `GuiSession`
- GuiPage.notify_success added after successful creation

### Example

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/ef0e7cd7-f88b-4886-9382-ef01ffacad92" />


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
