### PR TITLE
ux: print version number in GUI footer and update version in bundled Mac app

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -6,7 +6,10 @@ from PyInstaller.building.build_main import Analysis, COLLECT, BUNDLE
 import sys
 import os
 import site
+from pathlib import Path
 
+version_file = Path(os.path.dirname(SPEC)) / "VERSION"
+app_version = version_file.read_text().lstrip("v") if version_file.exists() else "dev"
 
 site_packages_path = None
 block_cipher = None
@@ -103,7 +106,7 @@ if sys.platform == "darwin":
         info_plist={
             'NSPrincipalClass': 'NSApplication',
             'NSHighResolutionCapable': 'True',
-            'CFBundleShortVersionString': '0.9.0',
+            'CFBundleShortVersionString': app_version,
             'CFBundleName': 'CIB Mango Tree',  # Display name (can have spaces)
         },
     )

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -9,7 +9,7 @@ import site
 from pathlib import Path
 
 version_file = Path(os.path.dirname(SPEC)) / "VERSION"
-app_version = version_file.read_text().lstrip("v") if version_file.exists() else "dev"
+app_version = version_file.read_text().strip().lstrip("v") if version_file.exists() else "dev"
 
 site_packages_path = None
 block_cipher = None

--- a/src/cibmangotree/gui/base.py
+++ b/src/cibmangotree/gui/base.py
@@ -19,6 +19,7 @@ from cibmangotree.gui.components.exit_confirmation import ExitConfirmationDialog
 from cibmangotree.gui.routes import gui_routes
 from cibmangotree.gui.session import GuiSession
 from cibmangotree.gui.theme import gui_colors, gui_urls
+from cibmangotree.meta.get_version import get_version
 
 
 class GuiPage(BaseModel, abc.ABC):
@@ -243,7 +244,11 @@ class GuiPage(BaseModel, abc.ABC):
             ):
                 # Left: License
                 with ui.element("div").classes("flex items-center"):
-                    ui.label("MIT License").classes("text-sm text-bold")
+                    version = get_version()
+                    version_str = f"{version}" if version else "dev"
+                    ui.label("MIT License · " + version_str).classes(
+                        "text-sm text-bold"
+                    )
 
                 # Center: Project attribution
                 with ui.element("div").classes("flex items-center gap-2"):

--- a/src/cibmangotree/meta/get_version.py
+++ b/src/cibmangotree/meta/get_version.py
@@ -1,19 +1,19 @@
-import os
-from functools import lru_cache
+import sys
 from pathlib import Path
 
 
-@lru_cache(maxsize=1)
 def get_version():
-    root_path = str(Path(__file__).resolve().parents[3])
-    version_path = os.path.join(root_path, "VERSION")
-    try:
-        with open(version_path, "r") as version_file:
-            return version_file.read().strip()
-    except FileNotFoundError:
-        return None
-    except PermissionError:  # Swallow this for now
-        return None
+    """Return version string if running as a bundled app, else None.
+
+    Bundled apps have a VERSION file at the root of the PyInstaller
+    extraction directory (sys._MEIPASS). Development runs always
+    return None so the GUI shows "dev".
+    """
+    if getattr(sys, "frozen", False):
+        version_path = Path(sys._MEIPASS) / "VERSION"
+        if version_path.exists():
+            return version_path.read_text().strip()
+    return None
 
 
 def is_distributed():

--- a/src/cibmangotree/meta/get_version.py
+++ b/src/cibmangotree/meta/get_version.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 @lru_cache(maxsize=1)
 def get_version():
-    root_path = str(Path(__file__).resolve().parent.parent)
+    root_path = str(Path(__file__).resolve().parents[3])
     version_path = os.path.join(root_path, "VERSION")
     try:
         with open(version_path, "r") as version_file:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The version in the bundled app was hard-coded and wrong.

Issue Number: #361

## What is the new behavior?

- update get_version.py to work with pyinstaller frozen build
- update pyinstaller.spec to read file from VERSION if it exists at build time
- update gui/pages/base.py to add version to footer

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
